### PR TITLE
Add Branch Search and Jump to HEAD Navigation

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -9,10 +9,13 @@ pub enum Action {
     PageDown,
     GoToTop,
     GoToBottom,
+    JumpToHead,
     NextBranch,
     PrevBranch,
     BranchLeft,
     BranchRight,
+    NextMatch,
+    PrevMatch,
 
     // Git operations
     Checkout,

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -37,6 +37,11 @@ fn map_normal_mode(key: KeyEvent) -> Option<Action> {
             Some(Action::GoToBottom)
         }
 
+        // Jump to HEAD
+        (KeyModifiers::SHIFT, KeyCode::Char('@')) | (KeyModifiers::NONE, KeyCode::Char('@')) => {
+            Some(Action::JumpToHead)
+        }
+
         // Branch jump
         (KeyModifiers::NONE, KeyCode::Char(']')) | (KeyModifiers::NONE, KeyCode::Tab) => {
             Some(Action::NextBranch)
@@ -61,6 +66,10 @@ fn map_normal_mode(key: KeyEvent) -> Option<Action> {
         // TODO: merge and rebase will be implemented in the future
         // (KeyModifiers::NONE, KeyCode::Char('m')) => Some(Action::Merge),
         // (KeyModifiers::NONE, KeyCode::Char('r')) => Some(Action::Rebase),
+
+        // Search navigation
+        (KeyModifiers::NONE, KeyCode::Char('n')) => Some(Action::NextMatch),
+        (KeyModifiers::SHIFT, KeyCode::Char('N')) => Some(Action::PrevMatch),
 
         // UI
         (KeyModifiers::NONE, KeyCode::Char('/')) => Some(Action::Search),

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -65,6 +65,10 @@ impl Widget for HelpPopup {
                 Span::styled("  G / End    ", key_style),
                 Span::styled("Go to bottom", desc_style),
             ]),
+            Line::from(vec![
+                Span::styled("  @          ", key_style),
+                Span::styled("Jump to HEAD (current branch)", desc_style),
+            ]),
             Line::from(""),
             Line::from(Span::styled("Git Operations", header_style)),
             Line::from(vec![
@@ -92,6 +96,20 @@ impl Widget for HelpPopup {
             //     Span::styled("  r          ", key_style),
             //     Span::styled("Rebase onto branch", desc_style),
             // ]),
+            Line::from(""),
+            Line::from(Span::styled("Search", header_style)),
+            Line::from(vec![
+                Span::styled("  /          ", key_style),
+                Span::styled("Search branches", desc_style),
+            ]),
+            Line::from(vec![
+                Span::styled("  n          ", key_style),
+                Span::styled("Next match", desc_style),
+            ]),
+            Line::from(vec![
+                Span::styled("  N          ", key_style),
+                Span::styled("Previous match", desc_style),
+            ]),
             Line::from(""),
             Line::from(Span::styled("Other", header_style)),
             Line::from(vec![


### PR DESCRIPTION
First of all, those 2 features (code and description) have entirely been vibe-coded. So feel free to decline the PR if you don't agree with that. But I have tested the result and that works well.
Also thanks for your contribution to the open source community :) Previously, I used serie but even if the UI is nice, it misses some features. Your tool fills the gap for me and I already adopted it. 

This PR adds two new navigation features to improve user experience when working with git branches in the TUI.

  ### Branch Search

  Quickly find and navigate to branches by name with incremental search.

  Keybindings:
  - / - Open branch search dialog
  - Type to search (case-insensitive substring matching)
  - Enter - Confirm search and keep matches active
  - n - Jump to next match
  - N - Jump to previous match (Shift+n)
  - Esc - Cancel search

  Behavior:
  - Incremental search updates as you type
  - Automatically jumps to first match
  - Navigate through multiple matches with n/N (wraps around)
  - Status bar shows "Match X/Y" or "No matches"
  - Search state persists after closing dialog until canceled or refresh

 ### Jump to HEAD

  Instantly return to the currently checked out branch from anywhere in the graph.

  Keybinding:
  - @ - Jump to HEAD (current checked out branch)

  Use cases:
  - Quickly return to your working branch after exploring history
  - Orient yourself in complex branch structures
  - Navigate back after using search or other navigation features