### PR TITLE
🐛 Fix search results disappearing during auto-refresh

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -377,7 +377,10 @@ impl App {
         }
 
         // Clear search state on refresh to avoid stale indices
-        self.search_state = SearchState::default();
+        // Skip if in search mode to prevent clearing active search results
+        if !self.is_in_search_mode() {
+            self.search_state = SearchState::default();
+        }
 
         // Clamp the selection
         let max_commit = self.graph_layout.nodes.len().saturating_sub(1);
@@ -432,6 +435,17 @@ impl App {
     /// Get current dropdown selection index
     pub fn search_selection(&self) -> Option<usize> {
         self.search_state.dropdown_selection
+    }
+
+    /// Check if currently in search input mode
+    pub fn is_in_search_mode(&self) -> bool {
+        matches!(
+            &self.mode,
+            AppMode::Input {
+                action: InputAction::Search,
+                ..
+            }
+        )
     }
 
     /// Jump to the currently checked out branch (HEAD)


### PR DESCRIPTION
## Summary

- Fix bug where search results would briefly appear then disappear
- Root cause: `refresh()` unconditionally reset `search_state`, which was triggered by auto-refresh and fetch completion
- Solution: Skip `search_state` reset when in search input mode

## Test plan

- [ ] Run `keifu` in any git repository
- [ ] Press `/` to enter search mode
- [ ] Type characters to search for branches
- [ ] Verify search results persist for 10+ seconds (no disappearing)
- [ ] Press Enter to confirm or Esc to cancel - both should work normally
- [ ] Press `r` after exiting search to verify manual refresh still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)