### PR TITLE
🐛 Fix repository open failure with relative worktrees

### DIFF
--- a/src/git/extensions.rs
+++ b/src/git/extensions.rs
@@ -1,0 +1,11 @@
+//! Git extension configuration for libgit2.
+
+use anyhow::{Context, Result};
+
+/// Configure extra repository extensions that libgit2 should accept.
+///
+/// This must run before opening repositories.
+pub fn configure_git_extensions() -> Result<()> {
+    unsafe { git2::opts::set_extensions(&["relativeworktrees"]) }
+        .context("failed to configure libgit2 supported extensions (relativeworktrees)")
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -3,6 +3,7 @@
 pub mod branch;
 pub mod commit;
 pub mod diff;
+pub mod extensions;
 pub mod graph;
 pub mod operations;
 pub mod repository;
@@ -10,5 +11,6 @@ pub mod repository;
 pub use branch::BranchInfo;
 pub use commit::CommitInfo;
 pub use diff::{CommitDiffInfo, FileChangeKind, FileDiffInfo};
+pub use extensions::configure_git_extensions;
 pub use graph::build_graph;
 pub use repository::{GitRepository, WorkingTreeStatus};

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use keifu::{
     app::App,
     event::{get_key_event, poll_event},
+    git::configure_git_extensions,
     keybindings::map_key_to_action,
     tui, ui,
 };
@@ -26,6 +27,8 @@ fn main() -> Result<()> {
         let _ = tui::restore();
         original_hook(panic_info);
     }));
+
+    configure_git_extensions()?;
 
     // Initialize application
     let mut app = App::new()?;


### PR DESCRIPTION
## Error Observed

> Error: Git repository not found. Please run inside a Git repository.
>
> Caused by:
> unsupported extension name extensions.relativeworktrees; class=Repository (6)

## Problem
- keifu could fail to open repositories in linked worktree setups using relative worktree metadata.

## Root Cause
- libgit2 rejected `extensions.relativeWorktrees` unless the extension was explicitly allowed.

## Fix
- initialize libgit2 extension support at startup
- explicitly allow `relativeworktrees` before repository discovery
- wire the initializer through the git module and call it before `App::new()`

## Testing
- `cargo test`
- run `keifu` in a worktree repository with `extensions.relativeWorktrees=true`