### PR TITLE
✨ Worktree support, branch triage list, and branch review

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,8 @@
+[advisories]
+# quick-xml DoS advisories (patched in >= 0.41.0). keifu cannot upgrade yet:
+# syntect -> plist pins quick-xml < 0.40, and no plist release allows 0.41.
+# Not reachable in keifu: quick-xml is only used by plist to parse
+# .tmLanguage/.tmTheme XML, while keifu loads syntect's bundled binary dumps
+# (SyntaxSet::load_defaults_newlines / ThemeSet::load_defaults) and never
+# parses untrusted XML. Remove once plist allows quick-xml >= 0.41.0.
+ignore = ["RUSTSEC-2026-0194", "RUSTSEC-2026-0195"]

--- a/src/action.rs
+++ b/src/action.rs
@@ -23,6 +23,15 @@ pub enum Action {
     Merge,
     Rebase,
 
+    // Worktrees
+    WorktreeCreate,
+    WorktreeRemove,
+
+    // Branch triage / review
+    OpenBranchList,
+    DeleteMergedBranches,
+    ReviewBranch,
+
     // Staging / commit / push
     StageToggle,
     StageAll,

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,15 +16,15 @@ use crate::{
     action::Action,
     config::Config,
     git::{
-        build_graph,
+        build_graph, collect_triage, default_base_branch,
         graph::GraphLayout,
         operations::{
             checkout_branch, checkout_commit, checkout_remote_branch, create_branch, create_commit,
             delete_branch, fetch_origin, merge_branch, push_branch, rebase_branch, stage_all,
-            stage_path, unstage_all, unstage_path,
+            stage_path, unstage_all, unstage_path, worktree_add, worktree_remove,
         },
-        BranchInfo, CommitDiffInfo, CommitInfo, FileDiffContent, FileDiffInfo, GitRepository,
-        StageState, WorkingTreeStatus,
+        BranchInfo, BranchTriageRow, CommitDiffInfo, CommitInfo, FileDiffContent, FileDiffInfo,
+        GitRepository, StageState, WorkingTreeStatus, WorktreeInfo,
     },
     perf::PerfStats,
     search::{fuzzy_search_branches, FuzzySearchResult},
@@ -74,6 +74,7 @@ pub enum AppMode {
     FileSelect {
         selected_index: usize,
         file_list: Vec<FileDiffInfo>,
+        source: DiffSource,
     },
     FileDiff {
         file_index: usize,
@@ -85,6 +86,26 @@ pub enum AppMode {
         horizontal_offset: usize,
         max_line_width: usize,
         total_lines: usize,
+        source: DiffSource,
+    },
+    BranchList {
+        selected: usize,
+        rows: Vec<BranchTriageRow>,
+        base_name: Option<String>,
+    },
+}
+
+/// Where the diff shown in FileSelect / FileDiff comes from
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiffSource {
+    /// Diff of the node selected in the graph (commit or uncommitted changes)
+    Selection,
+    /// Branch review: merge-base..branch tip (`git diff base...branch`)
+    Range {
+        base: Oid,
+        head: Oid,
+        base_name: String,
+        head_name: String,
     },
 }
 
@@ -94,6 +115,7 @@ pub enum InputAction {
     CreateBranch,
     Search,
     CommitMessage,
+    CreateWorktree { branch: String },
 }
 
 /// Focusable panes in Normal mode
@@ -120,6 +142,15 @@ pub enum ConfirmAction {
     Merge(String),
     Rebase(String),
     Push(String),
+    RemoveWorktree {
+        branch: String,
+        path: String,
+        from_list: bool,
+    },
+    /// Delete a branch from the branch list (returns to the list afterwards)
+    DeleteBranchFromList(String),
+    /// Bulk-delete merged branches from the branch list
+    DeleteMergedBranches(Vec<String>),
 }
 
 /// Result of async diff computation
@@ -210,7 +241,13 @@ pub struct App {
     pub commits: Vec<CommitInfo>,
     pub branches: Vec<BranchInfo>,
     pub graph_layout: GraphLayout,
+    pub worktrees: Vec<WorktreeInfo>,
     show_remote_branches: bool,
+
+    /// Diff shown while reviewing a branch (FileSelect/FileDiff with a Range source)
+    pub review_diff: Option<CommitDiffInfo>,
+    /// Scroll offset of the branch list (updated during render, for mouse hit-testing)
+    pub branch_list_scroll: u16,
 
     // UI state
     pub graph_list_state: ListState,
@@ -325,6 +362,7 @@ impl App {
         let show_remote_branches = config.graph.show_remote_branches;
         let commits = repo.get_commits(500, show_remote_branches)?;
         let branches = repo.get_branches(show_remote_branches)?;
+        let worktrees = WorktreeInfo::list_all(&repo.repo).unwrap_or_default();
         let (working_tree_status, stage_states, initial_message) =
             Self::working_tree_snapshot(&repo);
         let initial_message_time = initial_message.as_ref().map(|_| now);
@@ -361,7 +399,10 @@ impl App {
             commits,
             branches,
             graph_layout,
+            worktrees,
             show_remote_branches,
+            review_diff: None,
+            branch_list_scroll: 0,
             graph_list_state,
             focused_pane: FocusedPane::default(),
             detail_scroll: 0,
@@ -553,6 +594,7 @@ impl App {
         let log_started = Instant::now();
         self.commits = self.repo.get_commits(500, self.show_remote_branches)?;
         self.branches = self.repo.get_branches(self.show_remote_branches)?;
+        self.worktrees = WorktreeInfo::list_all(&self.repo.repo).unwrap_or_default();
         self.perf.record("refresh.log", log_started.elapsed());
         let head_commit_oid = self.repo.head_oid();
         let graph_started = Instant::now();
@@ -749,7 +791,9 @@ impl App {
                 self.reset_timers();
                 if matches!(
                     self.mode,
-                    AppMode::FileSelect { .. } | AppMode::FileDiff { .. }
+                    AppMode::FileSelect { .. }
+                        | AppMode::FileDiff { .. }
+                        | AppMode::BranchList { .. }
                 ) {
                     self.pending_refresh = true;
                     self.set_message("Fetched from origin");
@@ -825,7 +869,7 @@ impl App {
         }
         if matches!(
             self.mode,
-            AppMode::FileSelect { .. } | AppMode::FileDiff { .. }
+            AppMode::FileSelect { .. } | AppMode::FileDiff { .. } | AppMode::BranchList { .. }
         ) {
             return;
         }
@@ -1100,6 +1144,7 @@ impl App {
             AppMode::Error { .. } => self.handle_error_action(action),
             AppMode::FileSelect { .. } => self.handle_file_select_action(action)?,
             AppMode::FileDiff { .. } => self.handle_file_diff_action(action)?,
+            AppMode::BranchList { .. } => self.handle_branch_list_action(action)?,
         }
         Ok(())
     }
@@ -1209,13 +1254,37 @@ impl App {
             Action::DeleteBranch => {
                 if let Some(branch) = self.selected_branch() {
                     if !branch.is_head && !branch.is_remote {
-                        self.mode = AppMode::Confirm {
-                            message: format!("Delete branch '{}'?", branch.name),
-                            action: ConfirmAction::DeleteBranch(branch.name.clone()),
-                        };
+                        let name = branch.name.clone();
+                        if let Some(worktree) = self.worktree_for_branch(&name) {
+                            let path = worktree.path.display().to_string();
+                            self.set_message(format!(
+                                "'{}' is checked out in worktree {} (press W to remove it first)",
+                                name, path
+                            ));
+                        } else {
+                            self.mode = AppMode::Confirm {
+                                message: format!("Delete branch '{}'?", name),
+                                action: ConfirmAction::DeleteBranch(name),
+                            };
+                        }
                     }
                 }
             }
+            Action::WorktreeCreate => match self.selected_branch_name().map(|s| s.to_string()) {
+                Some(name) => self.request_worktree_create(&name),
+                None => self.set_message("No branch selected"),
+            },
+            Action::WorktreeRemove => match self.selected_branch_name().map(|s| s.to_string()) {
+                Some(name) => self.request_worktree_remove(&name),
+                None => self.set_message("No branch selected"),
+            },
+            Action::OpenBranchList => {
+                self.enter_branch_list(None);
+            }
+            Action::ReviewBranch => match self.selected_branch_name().map(|s| s.to_string()) {
+                Some(name) => self.start_branch_review(&name),
+                None => self.set_message("No branch selected"),
+            },
             Action::Merge => {
                 if let Some(branch) = self.selected_branch() {
                     if !branch.is_head {
@@ -1245,6 +1314,7 @@ impl App {
                         self.mode = AppMode::FileSelect {
                             selected_index: 0,
                             file_list,
+                            source: DiffSource::Selection,
                         };
                     }
                 } else if self.is_diff_loading() {
@@ -1336,6 +1406,7 @@ impl App {
         let AppMode::FileSelect {
             selected_index,
             file_list,
+            ..
         } = &self.mode
         else {
             return Ok(());
@@ -1355,15 +1426,20 @@ impl App {
                 }
             }
             Action::OpenFileDiff => {
-                let file_list_snapshot = if let AppMode::FileSelect { file_list, .. } = &self.mode {
-                    file_list.clone()
-                } else {
-                    return Ok(());
-                };
+                let (file_list_snapshot, source) =
+                    if let AppMode::FileSelect {
+                        file_list, source, ..
+                    } = &self.mode
+                    {
+                        (file_list.clone(), source.clone())
+                    } else {
+                        return Ok(());
+                    };
 
                 if selected_index < file_list_snapshot.len() {
                     let path = file_list_snapshot[selected_index].path.clone();
-                    if let Err(e) = self.enter_file_diff(selected_index, file_list_snapshot, &path)
+                    if let Err(e) =
+                        self.enter_file_diff(selected_index, file_list_snapshot, &path, source)
                     {
                         self.set_message(format!("Cannot open diff: {e}"));
                     }
@@ -1501,25 +1577,35 @@ impl App {
                 }
             }
             Action::NextFile => {
-                let file_list_snapshot = if let AppMode::FileDiff { file_list, .. } = &self.mode {
-                    file_list.clone()
-                } else {
-                    return Ok(());
-                };
+                let (file_list_snapshot, source) =
+                    if let AppMode::FileDiff {
+                        file_list, source, ..
+                    } = &self.mode
+                    {
+                        (file_list.clone(), source.clone())
+                    } else {
+                        return Ok(());
+                    };
                 if !file_list_snapshot.is_empty() {
                     let new_index = (file_index + 1) % file_list_snapshot.len();
                     let path = file_list_snapshot[new_index].path.clone();
-                    if let Err(e) = self.enter_file_diff(new_index, file_list_snapshot, &path) {
+                    if let Err(e) =
+                        self.enter_file_diff(new_index, file_list_snapshot, &path, source)
+                    {
                         self.set_message(format!("Cannot open diff: {e}"));
                     }
                 }
             }
             Action::PrevFile => {
-                let file_list_snapshot = if let AppMode::FileDiff { file_list, .. } = &self.mode {
-                    file_list.clone()
-                } else {
-                    return Ok(());
-                };
+                let (file_list_snapshot, source) =
+                    if let AppMode::FileDiff {
+                        file_list, source, ..
+                    } = &self.mode
+                    {
+                        (file_list.clone(), source.clone())
+                    } else {
+                        return Ok(());
+                    };
                 if !file_list_snapshot.is_empty() {
                     let new_index = if file_index == 0 {
                         file_list_snapshot.len() - 1
@@ -1527,26 +1613,30 @@ impl App {
                         file_index - 1
                     };
                     let path = file_list_snapshot[new_index].path.clone();
-                    if let Err(e) = self.enter_file_diff(new_index, file_list_snapshot, &path) {
+                    if let Err(e) =
+                        self.enter_file_diff(new_index, file_list_snapshot, &path, source)
+                    {
                         self.set_message(format!("Cannot open diff: {e}"));
                     }
                 }
             }
             Action::Cancel | Action::Quit => {
                 // Return to FileSelect with file_index preserved
-                let (file_index, file_list) = if let AppMode::FileDiff {
+                let (file_index, file_list, source) = if let AppMode::FileDiff {
                     file_index,
                     file_list,
+                    source,
                     ..
                 } = &self.mode
                 {
-                    (*file_index, file_list.clone())
+                    (*file_index, file_list.clone(), source.clone())
                 } else {
                     return Ok(());
                 };
                 self.mode = AppMode::FileSelect {
                     selected_index: file_index,
                     file_list,
+                    source,
                 };
             }
             _ => {}
@@ -1559,6 +1649,7 @@ impl App {
         file_index: usize,
         file_list: Vec<FileDiffInfo>,
         file_path: &std::path::Path,
+        source: DiffSource,
     ) -> Result<()> {
         use crate::ui::file_diff_view::build_highlighted_lines;
 
@@ -1566,7 +1657,7 @@ impl App {
         // files, large refactors) this may briefly block input. If this becomes a problem,
         // consider moving to a background task with a loading state, similar to commit diff summaries.
         let started = Instant::now();
-        let content = self.load_file_diff_content(file_path)?;
+        let content = self.load_file_diff_content(file_path, &source)?;
         let (rendered_lines, hunk_positions) = build_highlighted_lines(&content);
         self.perf.record("open_file_diff", started.elapsed());
         let total_lines = rendered_lines.len();
@@ -1582,11 +1673,19 @@ impl App {
             horizontal_offset: 0,
             max_line_width,
             total_lines,
+            source,
         };
         Ok(())
     }
 
-    fn load_file_diff_content(&self, file_path: &std::path::Path) -> Result<FileDiffContent> {
+    fn load_file_diff_content(
+        &self,
+        file_path: &std::path::Path,
+        source: &DiffSource,
+    ) -> Result<FileDiffContent> {
+        if let DiffSource::Range { base, head, .. } = source {
+            return FileDiffContent::from_range(&self.repo.repo, *base, *head, file_path);
+        }
         match self.current_diff_target() {
             Some(DiffTarget::Commit(oid)) => {
                 FileDiffContent::from_commit(&self.repo.repo, oid, file_path)
@@ -1602,6 +1701,20 @@ impl App {
     /// updated so that navigation and display stay consistent.
     fn sync_file_list_with_uncommitted_diff(&mut self) {
         if self.current_diff_target() != Some(DiffTarget::Uncommitted) {
+            return;
+        }
+
+        // A branch review shows a Range diff; never overwrite its file list
+        if matches!(
+            &self.mode,
+            AppMode::FileSelect {
+                source: DiffSource::Range { .. },
+                ..
+            } | AppMode::FileDiff {
+                source: DiffSource::Range { .. },
+                ..
+            }
+        ) {
             return;
         }
 
@@ -1625,6 +1738,7 @@ impl App {
             AppMode::FileSelect {
                 selected_index,
                 file_list,
+                ..
             } => {
                 *file_list = new_files;
                 if *selected_index >= file_list.len() {
@@ -1652,6 +1766,7 @@ impl App {
 
     fn return_to_normal(&mut self) {
         self.mode = AppMode::Normal;
+        self.review_diff = None;
         if self.pending_refresh {
             self.pending_refresh = false;
             if let Err(e) = self.refresh(true) {
@@ -1696,6 +1811,16 @@ impl App {
                         }
                         let oid = create_commit(&self.repo.repo, &message)?;
                         self.set_message(format!("Committed {}", &oid.to_string()[..7]));
+                        self.refresh(true)?;
+                    }
+                    InputAction::CreateWorktree { branch } => {
+                        let path = input.trim().to_string();
+                        if path.is_empty() {
+                            self.set_message("Worktree path is empty");
+                            return Ok(());
+                        }
+                        worktree_add(&self.repo_path, &path, &branch)?;
+                        self.set_message(format!("Created worktree at {}", path));
                         self.refresh(true)?;
                     }
                 }
@@ -1800,12 +1925,65 @@ impl App {
                         self.mode = AppMode::Normal;
                         return Ok(());
                     }
+                    ConfirmAction::RemoveWorktree {
+                        branch,
+                        path,
+                        from_list,
+                    } => {
+                        worktree_remove(&self.repo_path, &path)?;
+                        self.set_message(format!("Removed worktree of '{}'", branch));
+                        if from_list {
+                            self.refresh(true)?;
+                            self.enter_branch_list(None);
+                            return Ok(());
+                        }
+                    }
+                    ConfirmAction::DeleteBranchFromList(name) => {
+                        delete_branch(&self.repo.repo, &name)?;
+                        self.set_message(format!("Deleted branch '{}'", name));
+                        self.refresh(true)?;
+                        self.enter_branch_list(None);
+                        return Ok(());
+                    }
+                    ConfirmAction::DeleteMergedBranches(names) => {
+                        let mut deleted = 0usize;
+                        let mut failed: Vec<String> = Vec::new();
+                        for name in &names {
+                            match delete_branch(&self.repo.repo, name) {
+                                Ok(()) => deleted += 1,
+                                Err(_) => failed.push(name.clone()),
+                            }
+                        }
+                        if failed.is_empty() {
+                            self.set_message(format!("Deleted {} merged branches", deleted));
+                        } else {
+                            self.set_message(format!(
+                                "Deleted {} branches ({} failed: {})",
+                                deleted,
+                                failed.len(),
+                                failed.join(", ")
+                            ));
+                        }
+                        self.refresh(true)?;
+                        self.enter_branch_list(None);
+                        return Ok(());
+                    }
                 }
                 self.refresh(true)?;
                 self.mode = AppMode::Normal;
             }
             Action::Cancel => {
-                self.mode = AppMode::Normal;
+                // Confirmations opened from the branch list return to it
+                match confirm_action {
+                    ConfirmAction::DeleteBranchFromList(name)
+                    | ConfirmAction::RemoveWorktree {
+                        branch: name,
+                        from_list: true,
+                        ..
+                    } => self.enter_branch_list(Some(&name)),
+                    ConfirmAction::DeleteMergedBranches(_) => self.enter_branch_list(None),
+                    _ => self.mode = AppMode::Normal,
+                }
             }
             _ => {}
         }
@@ -1857,6 +2035,7 @@ impl App {
         self.mode = AppMode::FileSelect {
             selected_index: file_idx,
             file_list,
+            source: DiffSource::Selection,
         };
     }
 
@@ -1898,6 +2077,7 @@ impl App {
         let AppMode::FileSelect {
             selected_index,
             file_list,
+            ..
         } = &self.mode
         else {
             return Ok(());
@@ -2081,6 +2261,9 @@ impl App {
     fn do_checkout(&mut self) -> Result<()> {
         if let Some(branch) = self.selected_branch() {
             let branch_name = branch.name.clone();
+            if self.guard_branch_in_worktree(&branch_name) {
+                return Ok(());
+            }
             if branch_name.starts_with("origin/") {
                 // For remote branches, create a local branch and check it out
                 checkout_remote_branch(&self.repo.repo, &branch_name)?;
@@ -2095,6 +2278,282 @@ impl App {
             }
         }
         Ok(())
+    }
+
+    /// Get the worktree that has the given branch checked out, if any
+    pub fn worktree_for_branch(&self, branch_name: &str) -> Option<&WorktreeInfo> {
+        self.worktrees
+            .iter()
+            .find(|w| w.branch.as_deref() == Some(branch_name))
+    }
+
+    /// Show a message and return true when the branch lives in another worktree
+    /// (git2 does not enforce the CLI's "already checked out elsewhere" rule)
+    fn guard_branch_in_worktree(&mut self, branch_name: &str) -> bool {
+        let Some(worktree) = self.worktree_for_branch(branch_name) else {
+            return false;
+        };
+        let path = worktree.path.display().to_string();
+        self.set_message(format!(
+            "'{}' is checked out in worktree {}",
+            branch_name, path
+        ));
+        true
+    }
+
+    /// Suggested worktree path: a sibling directory of the repository
+    fn default_worktree_path(&self, branch_name: &str) -> String {
+        let repo_dir = std::path::Path::new(&self.repo_path);
+        let dir_name = repo_dir
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "worktree".to_string());
+        let sanitized = branch_name.replace('/', "-");
+        repo_dir
+            .parent()
+            .unwrap_or(repo_dir)
+            .join(format!("{}-{}", dir_name, sanitized))
+            .display()
+            .to_string()
+    }
+
+    /// Open the worktree path input for the given branch (key: w)
+    fn request_worktree_create(&mut self, branch_name: &str) {
+        if branch_name.starts_with("origin/") {
+            self.set_message("Cannot create a worktree for a remote branch");
+            return;
+        }
+        if self.head_name.as_deref() == Some(branch_name) {
+            self.set_message(format!("'{}' is already checked out here", branch_name));
+            return;
+        }
+        if let Some(worktree) = self.worktree_for_branch(branch_name) {
+            let path = worktree.path.display().to_string();
+            self.set_message(format!(
+                "'{}' already has a worktree at {}",
+                branch_name, path
+            ));
+            return;
+        }
+        self.mode = AppMode::Input {
+            title: format!("Worktree path for '{}'", branch_name),
+            input: self.default_worktree_path(branch_name),
+            action: InputAction::CreateWorktree {
+                branch: branch_name.to_string(),
+            },
+        };
+    }
+
+    /// Open the remove-worktree confirmation for the given branch (key: W)
+    fn request_worktree_remove(&mut self, branch_name: &str) {
+        let from_list = matches!(self.mode, AppMode::BranchList { .. });
+        let Some(worktree) = self.worktree_for_branch(branch_name) else {
+            self.set_message(format!("No worktree for '{}'", branch_name));
+            return;
+        };
+        let path = worktree.path.display().to_string();
+        self.mode = AppMode::Confirm {
+            message: format!("Remove worktree at {}?", path),
+            action: ConfirmAction::RemoveWorktree {
+                branch: branch_name.to_string(),
+                path,
+                from_list,
+            },
+        };
+    }
+
+    /// Open the branch triage list (key: B), optionally selecting a branch
+    fn enter_branch_list(&mut self, select: Option<&str>) {
+        match collect_triage(&self.repo.repo, &self.worktrees) {
+            Ok((base_name, rows)) => {
+                let selected = select
+                    .and_then(|name| rows.iter().position(|row| row.name == name))
+                    .unwrap_or(0);
+                self.branch_list_scroll = 0;
+                self.mode = AppMode::BranchList {
+                    selected,
+                    rows,
+                    base_name,
+                };
+            }
+            Err(e) => self.show_error(format!("Failed to list branches: {e}")),
+        }
+    }
+
+    /// Start reviewing a branch against the base branch (key: v):
+    /// shows the diff merge-base..branch, i.e. `git diff base...branch`
+    fn start_branch_review(&mut self, branch_name: &str) {
+        let repo = &self.repo.repo;
+        let Some((base_name, base_oid)) = default_base_branch(repo) else {
+            self.set_message("No base branch found (main/master)");
+            return;
+        };
+        if branch_name == base_name {
+            self.set_message(format!("'{}' is the base branch itself", branch_name));
+            return;
+        }
+        let Some(head_oid) = self
+            .branches
+            .iter()
+            .find(|b| b.name == branch_name)
+            .map(|b| b.tip_oid)
+        else {
+            self.set_message(format!("Branch '{}' not found", branch_name));
+            return;
+        };
+
+        let merge_base = match repo.merge_base(base_oid, head_oid) {
+            Ok(oid) => oid,
+            Err(e) => {
+                self.set_message(format!("No merge base with {}: {}", base_name, e));
+                return;
+            }
+        };
+        let diff = match CommitDiffInfo::from_range(repo, merge_base, head_oid) {
+            Ok(diff) => diff,
+            Err(e) => {
+                self.show_error(format!("Failed to compute branch diff: {e}"));
+                return;
+            }
+        };
+        if diff.files.is_empty() {
+            self.set_message(format!(
+                "No changes between {} and {}",
+                base_name, branch_name
+            ));
+            return;
+        }
+
+        // Keep the graph cursor in sync with the branch under review
+        if let Some(pos) = self
+            .branch_positions
+            .iter()
+            .position(|(_, name)| name == branch_name)
+        {
+            self.selected_branch_position = Some(pos);
+            if let Some((node_idx, _)) = self.branch_positions.get(pos) {
+                self.graph_list_state.select(Some(*node_idx));
+            }
+        }
+
+        let file_list = diff.files.clone();
+        self.review_diff = Some(diff);
+        self.mode = AppMode::FileSelect {
+            selected_index: 0,
+            file_list,
+            source: DiffSource::Range {
+                base: merge_base,
+                head: head_oid,
+                base_name,
+                head_name: branch_name.to_string(),
+            },
+        };
+    }
+
+    /// Handle actions in the branch list mode
+    fn handle_branch_list_action(&mut self, action: Action) -> Result<()> {
+        let AppMode::BranchList { selected, rows, .. } = &self.mode else {
+            return Ok(());
+        };
+        let selected = *selected;
+        let rows = rows.clone();
+        let selected_row = rows.get(selected).cloned();
+
+        match action {
+            Action::MoveDown => self.branch_list_move(selected + 1),
+            Action::MoveUp => self.branch_list_move(selected.saturating_sub(1)),
+            Action::PageDown => self.branch_list_move(selected + 10),
+            Action::PageUp => self.branch_list_move(selected.saturating_sub(10)),
+            Action::GoToTop => self.branch_list_move(0),
+            Action::GoToBottom => self.branch_list_move(usize::MAX),
+            Action::Checkout => {
+                let Some(row) = selected_row else {
+                    return Ok(());
+                };
+                if row.is_head {
+                    self.set_message(format!("'{}' is already checked out", row.name));
+                } else if !self.guard_branch_in_worktree(&row.name) {
+                    checkout_branch(&self.repo.repo, &row.name)?;
+                    self.set_message(format!("Checked out '{}'", row.name));
+                    self.refresh(true)?;
+                    self.enter_branch_list(Some(&row.name));
+                }
+            }
+            Action::DeleteBranch => {
+                let Some(row) = selected_row else {
+                    return Ok(());
+                };
+                if row.is_head {
+                    self.set_message("Cannot delete the current branch");
+                } else if let Some(path) = &row.worktree_path {
+                    self.set_message(format!(
+                        "'{}' is checked out in worktree {} (press W to remove it first)",
+                        row.name,
+                        path.display()
+                    ));
+                } else {
+                    let mut message = format!("Delete branch '{}'?", row.name);
+                    if !row.merged {
+                        message = format!(
+                            "Delete branch '{}'? (NOT merged: {} commits ahead)",
+                            row.name, row.ahead
+                        );
+                    }
+                    self.mode = AppMode::Confirm {
+                        message,
+                        action: ConfirmAction::DeleteBranchFromList(row.name),
+                    };
+                }
+            }
+            Action::DeleteMergedBranches => {
+                let names: Vec<String> = rows
+                    .iter()
+                    .filter(|row| {
+                        row.merged && !row.is_head && !row.is_base && row.worktree_path.is_none()
+                    })
+                    .map(|row| row.name.clone())
+                    .collect();
+                if names.is_empty() {
+                    self.set_message("No merged branches to delete");
+                } else {
+                    self.mode = AppMode::Confirm {
+                        message: format!(
+                            "Delete {} merged branches? ({})",
+                            names.len(),
+                            names.join(", ")
+                        ),
+                        action: ConfirmAction::DeleteMergedBranches(names),
+                    };
+                }
+            }
+            Action::ReviewBranch => {
+                if let Some(row) = selected_row {
+                    self.start_branch_review(&row.name);
+                }
+            }
+            Action::WorktreeCreate => {
+                if let Some(row) = selected_row {
+                    self.request_worktree_create(&row.name);
+                }
+            }
+            Action::WorktreeRemove => {
+                if let Some(row) = selected_row {
+                    self.request_worktree_remove(&row.name);
+                }
+            }
+            Action::Cancel | Action::Quit => {
+                self.return_to_normal();
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Move the branch list selection to the given index (clamped)
+    pub fn branch_list_move(&mut self, target: usize) {
+        if let AppMode::BranchList { selected, rows, .. } = &mut self.mode {
+            *selected = target.min(rows.len().saturating_sub(1));
+        }
     }
 
     /// Build a flat list of (node_index, branch_name) for all branches
@@ -2203,7 +2662,10 @@ mod tests {
             commits,
             branches,
             graph_layout,
+            worktrees: Vec::new(),
             show_remote_branches,
+            review_diff: None,
+            branch_list_scroll: 0,
             graph_list_state,
             focused_pane: FocusedPane::default(),
             detail_scroll: 0,
@@ -2281,7 +2743,10 @@ mod tests {
                 nodes: vec![node],
                 max_lane: 0,
             },
+            worktrees: Vec::new(),
             show_remote_branches: true,
+            review_diff: None,
+            branch_list_scroll: 0,
             graph_list_state,
             focused_pane: FocusedPane::default(),
             detail_scroll: 0,

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,6 +30,19 @@ use crate::{
     search::{fuzzy_search_branches, FuzzySearchResult},
 };
 
+/// Translate raw git2 checkout errors into actionable messages
+/// (e.g. "class=Checkout (20); code=Conflict (-13)" tells the user nothing)
+fn friendly_checkout_error(err: anyhow::Error) -> anyhow::Error {
+    let is_conflict = err
+        .downcast_ref::<git2::Error>()
+        .is_some_and(|e| e.code() == git2::ErrorCode::Conflict);
+    if is_conflict {
+        anyhow::anyhow!("Checkout failed: uncommitted changes would be overwritten (commit or stash them first)")
+    } else {
+        err
+    }
+}
+
 /// Filter branch names to exclude remote branches that have matching local branches
 /// Returns branches in order: local branches first, then remote-only branches
 fn filter_remote_duplicates(branch_names: &[String]) -> Vec<&str> {
@@ -168,6 +181,9 @@ enum DiffTarget {
 
 type UncommittedDiffResult = (Result<CommitDiffInfo, String>, Option<WorkingTreeStatus>);
 
+/// Result of async branch review diff computation
+type ReviewResult = (DiffSource, Result<CommitDiffInfo, String>);
+
 /// Delay before starting a diff load after selection changes.
 /// Prevents unnecessary computation during fast scrolling.
 const DIFF_LOAD_DEBOUNCE: Duration = Duration::from_millis(120);
@@ -246,6 +262,8 @@ pub struct App {
 
     /// Diff shown while reviewing a branch (FileSelect/FileDiff with a Range source)
     pub review_diff: Option<CommitDiffInfo>,
+    /// In-flight branch review computation (receiver, started at)
+    review_receiver: Option<(Receiver<ReviewResult>, Instant)>,
     /// Scroll offset of the branch list (updated during render, for mouse hit-testing)
     pub branch_list_scroll: u16,
 
@@ -402,6 +420,7 @@ impl App {
             worktrees,
             show_remote_branches,
             review_diff: None,
+            review_receiver: None,
             branch_list_scroll: 0,
             graph_list_state,
             focused_pane: FocusedPane::default(),
@@ -933,8 +952,9 @@ impl App {
     pub fn get_message(&self) -> Option<&str> {
         const MESSAGE_TIMEOUT_SECS: u64 = 5;
 
-        // Don't timeout while fetching or pushing
-        if self.is_fetching() || self.is_pushing() {
+        // Don't timeout while a user-visible async operation is running
+        // (silent auto-fetch must not pin unrelated messages)
+        if (self.is_fetching() && !self.fetch_silent) || self.is_pushing() || self.is_reviewing() {
             return self.message.as_deref();
         }
 
@@ -1152,6 +1172,10 @@ impl App {
     /// Show an error
     pub fn show_error(&mut self, message: String) {
         tracing::warn!(%message, "showing error");
+        // An in-progress status line (e.g. "Pushing...") is stale once the
+        // operation failed; without this it would linger as long as any
+        // async operation keeps message expiry suppressed.
+        self.message = None;
         self.mode = AppMode::Error { message };
     }
 
@@ -2013,6 +2037,27 @@ impl App {
         self.sync_branch_selection_to_node(new);
     }
 
+    /// Keep the graph scroll offset valid and the selection visible.
+    /// The graph view builds items for the visible window only, so the
+    /// offset must be synced before rendering instead of letting the
+    /// List widget adjust it (same scroll-into-view rule as ratatui's List).
+    pub fn clamp_graph_offset(&mut self, viewport: usize) {
+        let len = self.graph_layout.nodes.len();
+        if len == 0 || viewport == 0 {
+            *self.graph_list_state.offset_mut() = 0;
+            return;
+        }
+        let selected = self.graph_list_state.selected().unwrap_or(0).min(len - 1);
+        let mut offset = self.graph_list_state.offset();
+        if selected < offset {
+            offset = selected;
+        } else if selected >= offset + viewport {
+            offset = selected + 1 - viewport;
+        }
+        offset = offset.min(len.saturating_sub(viewport));
+        *self.graph_list_state.offset_mut() = offset;
+    }
+
     /// Select a graph node by absolute index (mouse click)
     pub fn select_node(&mut self, idx: usize) {
         if idx >= self.graph_layout.nodes.len() {
@@ -2264,16 +2309,22 @@ impl App {
             if self.guard_branch_in_worktree(&branch_name) {
                 return Ok(());
             }
-            if branch_name.starts_with("origin/") {
+            let result = if branch_name.starts_with("origin/") {
                 // For remote branches, create a local branch and check it out
-                checkout_remote_branch(&self.repo.repo, &branch_name)?;
+                checkout_remote_branch(&self.repo.repo, &branch_name)
             } else {
-                checkout_branch(&self.repo.repo, &branch_name)?;
-            }
+                checkout_branch(&self.repo.repo, &branch_name)
+            };
+            result.map_err(friendly_checkout_error)?;
+            self.set_message(format!("Checked out '{}'", branch_name));
             self.refresh(true)?;
         } else if let Some(node) = self.selected_commit_node() {
             if let Some(commit) = &node.commit {
-                checkout_commit(&self.repo.repo, commit.oid)?;
+                checkout_commit(&self.repo.repo, commit.oid).map_err(friendly_checkout_error)?;
+                self.set_message(format!(
+                    "Checked out {} (detached HEAD)",
+                    &commit.oid.to_string()[..7]
+                ));
                 self.refresh(true)?;
             }
         }
@@ -2364,7 +2415,10 @@ impl App {
 
     /// Open the branch triage list (key: B), optionally selecting a branch
     fn enter_branch_list(&mut self, select: Option<&str>) {
-        match collect_triage(&self.repo.repo, &self.worktrees) {
+        let started = Instant::now();
+        let triage = collect_triage(&self.repo.repo, &self.worktrees);
+        self.perf.record("branch_list.triage", started.elapsed());
+        match triage {
             Ok((base_name, rows)) => {
                 let selected = select
                     .and_then(|name| rows.iter().position(|row| row.name == name))
@@ -2381,8 +2435,14 @@ impl App {
     }
 
     /// Start reviewing a branch against the base branch (key: v):
-    /// shows the diff merge-base..branch, i.e. `git diff base...branch`
+    /// shows the diff merge-base..branch, i.e. `git diff base...branch`.
+    /// The diff is computed in a background thread (it can be large);
+    /// `update_review_status` opens the file list when it completes.
     fn start_branch_review(&mut self, branch_name: &str) {
+        if self.review_receiver.is_some() {
+            self.set_message("A branch review is already being computed");
+            return;
+        }
         let repo = &self.repo.repo;
         let Some((base_name, base_oid)) = default_base_branch(repo) else {
             self.set_message("No base branch found (main/master)");
@@ -2409,7 +2469,58 @@ impl App {
                 return;
             }
         };
-        let diff = match CommitDiffInfo::from_range(repo, merge_base, head_oid) {
+
+        let source = DiffSource::Range {
+            base: merge_base,
+            head: head_oid,
+            base_name: base_name.clone(),
+            head_name: branch_name.to_string(),
+        };
+        let (tx, rx) = mpsc::channel();
+        let repo_path = self.repo_path.clone();
+        thread::spawn(move || {
+            let diff = git2::Repository::open(&repo_path)
+                .map_err(|e| e.to_string())
+                .and_then(|repo| {
+                    CommitDiffInfo::from_range(&repo, merge_base, head_oid)
+                        .map_err(|e| e.to_string())
+                });
+            let _ = tx.send((source, diff));
+        });
+        self.review_receiver = Some((rx, Instant::now()));
+        self.set_message(format!("Reviewing {}…{}", base_name, branch_name));
+    }
+
+    /// Whether a branch review diff is being computed
+    pub fn is_reviewing(&self) -> bool {
+        self.review_receiver.is_some()
+    }
+
+    /// Check if the async branch review diff has completed and open it
+    pub fn update_review_status(&mut self) {
+        let Some((rx, started)) = &self.review_receiver else {
+            return;
+        };
+        let Ok((source, result)) = rx.try_recv() else {
+            return;
+        };
+        self.perf.record("review.diff", started.elapsed());
+        self.review_receiver = None;
+
+        // A modal dialog opened while computing wins; drop the result
+        if !matches!(self.mode, AppMode::Normal | AppMode::BranchList { .. }) {
+            return;
+        }
+        let DiffSource::Range {
+            ref base_name,
+            ref head_name,
+            ..
+        } = source
+        else {
+            return;
+        };
+
+        let diff = match result {
             Ok(diff) => diff,
             Err(e) => {
                 self.show_error(format!("Failed to compute branch diff: {e}"));
@@ -2419,7 +2530,7 @@ impl App {
         if diff.files.is_empty() {
             self.set_message(format!(
                 "No changes between {} and {}",
-                base_name, branch_name
+                base_name, head_name
             ));
             return;
         }
@@ -2428,7 +2539,7 @@ impl App {
         if let Some(pos) = self
             .branch_positions
             .iter()
-            .position(|(_, name)| name == branch_name)
+            .position(|(_, name)| name == head_name)
         {
             self.selected_branch_position = Some(pos);
             if let Some((node_idx, _)) = self.branch_positions.get(pos) {
@@ -2436,36 +2547,44 @@ impl App {
             }
         }
 
+        self.message = None;
         let file_list = diff.files.clone();
         self.review_diff = Some(diff);
         self.mode = AppMode::FileSelect {
             selected_index: 0,
             file_list,
-            source: DiffSource::Range {
-                base: merge_base,
-                head: head_oid,
-                base_name,
-                head_name: branch_name.to_string(),
-            },
+            source,
         };
     }
 
     /// Handle actions in the branch list mode
     fn handle_branch_list_action(&mut self, action: Action) -> Result<()> {
-        let AppMode::BranchList { selected, rows, .. } = &self.mode else {
+        let AppMode::BranchList { selected, .. } = &self.mode else {
             return Ok(());
         };
         let selected = *selected;
-        let rows = rows.clone();
+
+        // Movement doesn't need row data; skip the clones below
+        let movement_target = match action {
+            Action::MoveDown => Some(selected + 1),
+            Action::MoveUp => Some(selected.saturating_sub(1)),
+            Action::PageDown => Some(selected + 10),
+            Action::PageUp => Some(selected.saturating_sub(10)),
+            Action::GoToTop => Some(0),
+            Action::GoToBottom => Some(usize::MAX),
+            _ => None,
+        };
+        if let Some(target) = movement_target {
+            self.branch_list_move(target);
+            return Ok(());
+        }
+
+        let AppMode::BranchList { rows, .. } = &self.mode else {
+            return Ok(());
+        };
         let selected_row = rows.get(selected).cloned();
 
         match action {
-            Action::MoveDown => self.branch_list_move(selected + 1),
-            Action::MoveUp => self.branch_list_move(selected.saturating_sub(1)),
-            Action::PageDown => self.branch_list_move(selected + 10),
-            Action::PageUp => self.branch_list_move(selected.saturating_sub(10)),
-            Action::GoToTop => self.branch_list_move(0),
-            Action::GoToBottom => self.branch_list_move(usize::MAX),
             Action::Checkout => {
                 let Some(row) = selected_row else {
                     return Ok(());
@@ -2473,7 +2592,7 @@ impl App {
                 if row.is_head {
                     self.set_message(format!("'{}' is already checked out", row.name));
                 } else if !self.guard_branch_in_worktree(&row.name) {
-                    checkout_branch(&self.repo.repo, &row.name)?;
+                    checkout_branch(&self.repo.repo, &row.name).map_err(friendly_checkout_error)?;
                     self.set_message(format!("Checked out '{}'", row.name));
                     self.refresh(true)?;
                     self.enter_branch_list(Some(&row.name));
@@ -2540,6 +2659,10 @@ impl App {
                 if let Some(row) = selected_row {
                     self.request_worktree_remove(&row.name);
                 }
+            }
+            Action::ToggleHelp => {
+                self.help_scroll = 0;
+                self.mode = AppMode::Help;
             }
             Action::Cancel | Action::Quit => {
                 self.return_to_normal();
@@ -2665,6 +2788,7 @@ mod tests {
             worktrees: Vec::new(),
             show_remote_branches,
             review_diff: None,
+            review_receiver: None,
             branch_list_scroll: 0,
             graph_list_state,
             focused_pane: FocusedPane::default(),
@@ -2746,6 +2870,7 @@ mod tests {
             worktrees: Vec::new(),
             show_remote_branches: true,
             review_diff: None,
+            review_receiver: None,
             branch_list_scroll: 0,
             graph_list_state,
             focused_pane: FocusedPane::default(),

--- a/src/debug_server.rs
+++ b/src/debug_server.rs
@@ -184,6 +184,7 @@ fn state_json(app: &App) -> Value {
         AppMode::Error { .. } => "error",
         AppMode::FileSelect { .. } => "file_select",
         AppMode::FileDiff { .. } => "file_diff",
+        AppMode::BranchList { .. } => "branch_list",
     };
     let focused = match app.focused_pane {
         FocusedPane::Graph => "graph",

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -21,8 +21,10 @@ impl BranchInfo {
     pub fn list_all(repo: &Repository, include_remotes: bool) -> Result<Vec<Self>> {
         let mut branches = Vec::new();
 
-        // Get HEAD
-        let head_oid = repo.head().ok().and_then(|r| r.target());
+        // Resolve HEAD once; the per-branch loop only compares by value
+        let head = repo.head().ok();
+        let head_oid = head.as_ref().and_then(|r| r.target());
+        let head_shorthand = head.as_ref().and_then(|r| r.shorthand());
 
         // Local branches
         for branch_result in repo.branches(Some(BranchType::Local))? {
@@ -30,12 +32,8 @@ impl BranchInfo {
             if let Some(name) = branch.name()? {
                 let reference = branch.get();
                 if let Some(oid) = reference.target() {
-                    let is_head = head_oid.map(|h| h == oid).unwrap_or(false)
-                        && repo
-                            .head()
-                            .ok()
-                            .and_then(|h| h.shorthand().map(|s| s == name))
-                            .unwrap_or(false);
+                    let is_head =
+                        head_oid == Some(oid) && head_shorthand.is_some_and(|h| h == name);
 
                     let upstream = branch
                         .upstream()

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -1,7 +1,12 @@
 //! Branch info structure and operations
 
+use std::path::PathBuf;
+
 use anyhow::Result;
+use chrono::{DateTime, Local, TimeZone};
 use git2::{BranchType, Oid, Repository};
+
+use super::worktree::WorktreeInfo;
 
 #[derive(Debug, Clone)]
 pub struct BranchInfo {
@@ -72,4 +77,109 @@ impl BranchInfo {
 
         Ok(branches)
     }
+}
+
+/// Detect the base branch to compare other branches against.
+/// Prefers origin/HEAD's target, then "main", then "master"; a local branch
+/// wins over its remote counterpart. Returns (display name, tip oid).
+pub fn default_base_branch(repo: &Repository) -> Option<(String, Oid)> {
+    let from_origin_head = repo
+        .find_reference("refs/remotes/origin/HEAD")
+        .ok()
+        .and_then(|r| r.symbolic_target().map(String::from))
+        .and_then(|t| t.strip_prefix("refs/remotes/origin/").map(String::from));
+
+    let candidates = from_origin_head
+        .into_iter()
+        .chain(["main".to_string(), "master".to_string()]);
+
+    for name in candidates {
+        if let Ok(branch) = repo.find_branch(&name, BranchType::Local) {
+            if let Some(oid) = branch.get().target() {
+                return Some((name, oid));
+            }
+        }
+        let remote_name = format!("origin/{name}");
+        if let Ok(branch) = repo.find_branch(&remote_name, BranchType::Remote) {
+            if let Some(oid) = branch.get().target() {
+                return Some((remote_name, oid));
+            }
+        }
+    }
+    None
+}
+
+/// One row of the branch triage list
+#[derive(Debug, Clone)]
+pub struct BranchTriageRow {
+    pub name: String,
+    pub tip_oid: Oid,
+    pub is_head: bool,
+    pub is_base: bool,
+    pub ahead: usize,
+    pub behind: usize,
+    /// Fully contained in the base branch (safe to delete)
+    pub merged: bool,
+    pub last_commit: DateTime<Local>,
+    pub subject: String,
+    pub worktree_path: Option<PathBuf>,
+}
+
+/// Collect triage info for all local branches, newest activity first
+/// (HEAD pinned to the top). Returns (base branch name, rows).
+pub fn collect_triage(
+    repo: &Repository,
+    worktrees: &[WorktreeInfo],
+) -> Result<(Option<String>, Vec<BranchTriageRow>)> {
+    let base = default_base_branch(repo);
+    let mut rows = Vec::new();
+
+    for branch_result in repo.branches(Some(BranchType::Local))? {
+        let (branch, _) = branch_result?;
+        let Some(name) = branch.name()? else {
+            continue;
+        };
+        let Some(tip_oid) = branch.get().target() else {
+            continue;
+        };
+        let commit = repo.find_commit(tip_oid)?;
+        let last_commit = Local
+            .timestamp_opt(commit.time().seconds(), 0)
+            .single()
+            .unwrap_or_else(Local::now);
+        let subject = commit.summary().unwrap_or("").to_string();
+
+        let is_base = base
+            .as_ref()
+            .is_some_and(|(base_name, _)| base_name == name);
+        let (ahead, behind) = match &base {
+            Some((_, base_oid)) if !is_base => repo.graph_ahead_behind(tip_oid, *base_oid)?,
+            _ => (0, 0),
+        };
+
+        rows.push(BranchTriageRow {
+            name: name.to_string(),
+            tip_oid,
+            is_head: branch.is_head(),
+            is_base,
+            ahead,
+            behind,
+            merged: base.is_some() && !is_base && ahead == 0,
+            last_commit,
+            subject,
+            worktree_path: worktrees
+                .iter()
+                .find(|w| w.branch.as_deref() == Some(name))
+                .map(|w| w.path.clone()),
+        });
+    }
+
+    rows.sort_by(|a, b| {
+        b.is_head
+            .cmp(&a.is_head)
+            .then(b.last_commit.cmp(&a.last_commit))
+            .then(a.name.cmp(&b.name))
+    });
+
+    Ok((base.map(|(name, _)| name), rows))
 }

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -149,6 +149,22 @@ impl CommitDiffInfo {
         Self::build_info(Self::scan_diff(&diff)?, None)
     }
 
+    /// Get diff info between two commits (e.g. merge-base..branch tip,
+    /// equivalent to `git diff base...branch`)
+    pub fn from_range(repo: &Repository, old_oid: Oid, new_oid: Oid) -> Result<Self> {
+        let old_tree = repo.find_commit(old_oid)?.tree()?;
+        let new_tree = repo.find_commit(new_oid)?.tree()?;
+
+        let mut opts = DiffOptions::new();
+        opts.minimal(false);
+        opts.ignore_submodules(true);
+        opts.context_lines(0);
+
+        let diff = repo.diff_tree_to_tree(Some(&old_tree), Some(&new_tree), Some(&mut opts))?;
+
+        Self::build_info(Self::scan_diff(&diff)?, None)
+    }
+
     fn scan_diff(diff: &Diff) -> Result<DiffScan> {
         let _ = diff.stats()?;
         let mut files = Vec::with_capacity(diff.deltas().len());
@@ -691,6 +707,27 @@ impl FileDiffContent {
         opts.disable_pathspec_match(true);
 
         let diff = repo.diff_tree_to_tree(old_tree.as_ref(), Some(&new_tree), Some(&mut opts))?;
+
+        Self::from_diff(&diff, file_path)
+    }
+
+    /// Get full diff content for a single file between two commits
+    pub fn from_range(
+        repo: &Repository,
+        old_oid: Oid,
+        new_oid: Oid,
+        file_path: &Path,
+    ) -> Result<Self> {
+        let old_tree = repo.find_commit(old_oid)?.tree()?;
+        let new_tree = repo.find_commit(new_oid)?.tree()?;
+
+        let mut opts = DiffOptions::new();
+        opts.ignore_submodules(true);
+        opts.context_lines(3);
+        opts.pathspec(file_path);
+        opts.disable_pathspec_match(true);
+
+        let diff = repo.diff_tree_to_tree(Some(&old_tree), Some(&new_tree), Some(&mut opts))?;
 
         Self::from_diff(&diff, file_path)
     }

--- a/src/git/graph.rs
+++ b/src/git/graph.rs
@@ -145,6 +145,8 @@ pub fn build_graph(
     let mut lanes: Vec<Option<Oid>> = Vec::new();
     let mut nodes: Vec<GraphNode> = Vec::new();
     let mut max_lane: usize = 0;
+    // Commits already emitted as rows (O(1) "already shown" checks)
+    let mut shown_oids: std::collections::HashSet<Oid> = std::collections::HashSet::new();
 
     // Color management
     let mut color_assigner = ColorAssigner::new();
@@ -290,9 +292,7 @@ pub fn build_graph(
                 .position(|l| l.map(|oid| oid == *parent_oid).unwrap_or(false));
 
             // Check if parent commit has already been shown
-            let parent_already_shown = nodes
-                .iter()
-                .any(|n| n.commit.as_ref().map(|c| c.oid) == Some(*parent_oid));
+            let parent_already_shown = shown_oids.contains(parent_oid);
 
             let (parent_lane, was_existing, parent_color) = if let Some(pl) = existing_parent_lane {
                 // If parent is a fork point, treat as fork sibling
@@ -391,6 +391,7 @@ pub fn build_graph(
         let is_head = head_oid.map(|h| h == commit.oid).unwrap_or(false);
 
         // Add commit row
+        shown_oids.insert(commit.oid);
         nodes.push(GraphNode {
             commit: Some(commit.clone()),
             lane,
@@ -414,11 +415,7 @@ pub fn build_graph(
             // Check if the ending lane is tracking a commit that hasn't been shown yet
             let ending_lane_oid = lanes.get(ending_lane).and_then(|o| *o);
             let ending_oid_already_shown = ending_lane_oid
-                .map(|oid| {
-                    nodes
-                        .iter()
-                        .any(|n| n.commit.as_ref().map(|c| c.oid) == Some(oid))
-                })
+                .map(|oid| shown_oids.contains(&oid))
                 .unwrap_or(true);
 
             let continues_down = !ending_oid_already_shown;

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -7,8 +7,9 @@ pub mod extensions;
 pub mod graph;
 pub mod operations;
 pub mod repository;
+pub mod worktree;
 
-pub use branch::BranchInfo;
+pub use branch::{collect_triage, default_base_branch, BranchInfo, BranchTriageRow};
 pub use commit::CommitInfo;
 pub use diff::{
     CommitDiffInfo, DiffHunkContent, DiffLineContent, DiffLineOrigin, FileChangeKind,
@@ -17,3 +18,4 @@ pub use diff::{
 pub use extensions::configure_git_extensions;
 pub use graph::build_graph;
 pub use repository::{GitRepository, StageState, WorkingTreeStatus};
+pub use worktree::WorktreeInfo;

--- a/src/git/operations.rs
+++ b/src/git/operations.rs
@@ -302,6 +302,39 @@ pub fn push_branch(repo_path: &str, branch: &str) -> Result<()> {
     Ok(())
 }
 
+/// Add a worktree for an existing branch using git command
+/// (the CLI enforces checkout rules like "branch already used elsewhere")
+pub fn worktree_add(repo_path: &str, worktree_path: &str, branch: &str) -> Result<()> {
+    let output = Command::new("git")
+        .args(["worktree", "add", worktree_path, branch])
+        .current_dir(repo_path)
+        .output()
+        .context("Failed to execute git worktree add")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git worktree add failed: {}", stderr.trim());
+    }
+
+    Ok(())
+}
+
+/// Remove a worktree using git command (refuses when it has local changes)
+pub fn worktree_remove(repo_path: &str, worktree_path: &str) -> Result<()> {
+    let output = Command::new("git")
+        .args(["worktree", "remove", worktree_path])
+        .current_dir(repo_path)
+        .output()
+        .context("Failed to execute git worktree remove")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git worktree remove failed: {}", stderr.trim());
+    }
+
+    Ok(())
+}
+
 /// Fetch from origin remote using git command
 pub fn fetch_origin(repo_path: &str) -> Result<()> {
     let output = Command::new("git")

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -21,16 +21,15 @@ impl WorktreeInfo {
             let Ok(worktree) = repo.find_worktree(name) else {
                 continue;
             };
-            let branch = Repository::open_from_worktree(&worktree)
-                .ok()
-                .and_then(|wt_repo| {
-                    let head = wt_repo.head().ok()?;
-                    if head.is_branch() {
-                        head.shorthand().map(|s| s.to_string())
-                    } else {
-                        None
-                    }
-                });
+            // Read the per-worktree HEAD file directly: this runs on every
+            // auto-refresh, and opening each worktree as a Repository would
+            // re-parse config/odb state just to learn the branch name.
+            let head_path = repo.path().join("worktrees").join(name).join("HEAD");
+            let branch = std::fs::read_to_string(head_path).ok().and_then(|head| {
+                head.trim()
+                    .strip_prefix("ref: refs/heads/")
+                    .map(|s| s.to_string())
+            });
             worktrees.push(WorktreeInfo {
                 name: name.to_string(),
                 path: worktree.path().to_path_buf(),

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -1,0 +1,42 @@
+//! Linked worktree listing
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use git2::Repository;
+
+#[derive(Debug, Clone)]
+pub struct WorktreeInfo {
+    pub name: String,
+    pub path: PathBuf,
+    /// Branch checked out in the worktree (None when detached or unreadable)
+    pub branch: Option<String>,
+}
+
+impl WorktreeInfo {
+    /// List linked worktrees (the main working tree is not included)
+    pub fn list_all(repo: &Repository) -> Result<Vec<Self>> {
+        let mut worktrees = Vec::new();
+        for name in repo.worktrees()?.iter().flatten() {
+            let Ok(worktree) = repo.find_worktree(name) else {
+                continue;
+            };
+            let branch = Repository::open_from_worktree(&worktree)
+                .ok()
+                .and_then(|wt_repo| {
+                    let head = wt_repo.head().ok()?;
+                    if head.is_branch() {
+                        head.shorthand().map(|s| s.to_string())
+                    } else {
+                        None
+                    }
+                });
+            worktrees.push(WorktreeInfo {
+                name: name.to_string(),
+                path: worktree.path().to_path_buf(),
+                branch,
+            });
+        }
+        Ok(worktrees)
+    }
+}

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -220,6 +220,9 @@ fn map_branch_list_mode(key: KeyEvent) -> Option<Action> {
         (KeyModifiers::NONE, KeyCode::Char('v')) => Some(Action::ReviewBranch),
         (KeyModifiers::NONE, KeyCode::Char('w')) => Some(Action::WorktreeCreate),
         (KeyModifiers::SHIFT, KeyCode::Char('W')) => Some(Action::WorktreeRemove),
+        // B toggles the list closed
+        (KeyModifiers::SHIFT, KeyCode::Char('B')) => Some(Action::Cancel),
+        (_, KeyCode::Char('?')) => Some(Action::ToggleHelp),
         (KeyModifiers::NONE, KeyCode::Esc) | (KeyModifiers::NONE, KeyCode::Char('q')) => {
             Some(Action::Cancel)
         }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -26,6 +26,7 @@ pub fn map_key_to_action(key: KeyEvent, mode: &AppMode) -> Option<Action> {
         AppMode::Error { .. } => map_error_mode(key),
         AppMode::FileSelect { .. } => map_file_select_mode(key),
         AppMode::FileDiff { .. } => map_file_diff_mode(key),
+        AppMode::BranchList { .. } => map_branch_list_mode(key),
     }
 }
 
@@ -78,6 +79,14 @@ fn map_normal_mode(key: KeyEvent) -> Option<Action> {
         (KeyModifiers::NONE, KeyCode::Char('f')) => Some(Action::Fetch),
         (KeyModifiers::NONE, KeyCode::Char('c')) => Some(Action::CommitDialog),
         (KeyModifiers::NONE, KeyCode::Char('p')) => Some(Action::Push),
+
+        // Worktrees
+        (KeyModifiers::NONE, KeyCode::Char('w')) => Some(Action::WorktreeCreate),
+        (KeyModifiers::SHIFT, KeyCode::Char('W')) => Some(Action::WorktreeRemove),
+
+        // Branch triage / review
+        (KeyModifiers::SHIFT, KeyCode::Char('B')) => Some(Action::OpenBranchList),
+        (KeyModifiers::NONE, KeyCode::Char('v')) => Some(Action::ReviewBranch),
 
         // Clipboard
         (KeyModifiers::NONE, KeyCode::Char('y')) => Some(Action::CopyHash),
@@ -182,6 +191,35 @@ fn map_file_select_mode(key: KeyEvent) -> Option<Action> {
         (KeyModifiers::NONE, KeyCode::Char('a')) => Some(Action::StageAll),
         (KeyModifiers::NONE, KeyCode::Char('u')) => Some(Action::UnstageAll),
         (KeyModifiers::NONE, KeyCode::Char('c')) => Some(Action::CommitDialog),
+        (KeyModifiers::NONE, KeyCode::Esc) | (KeyModifiers::NONE, KeyCode::Char('q')) => {
+            Some(Action::Cancel)
+        }
+        _ => None,
+    }
+}
+
+fn map_branch_list_mode(key: KeyEvent) -> Option<Action> {
+    match (key.modifiers, key.code) {
+        (KeyModifiers::NONE, KeyCode::Char('j')) | (KeyModifiers::NONE, KeyCode::Down) => {
+            Some(Action::MoveDown)
+        }
+        (KeyModifiers::NONE, KeyCode::Char('k')) | (KeyModifiers::NONE, KeyCode::Up) => {
+            Some(Action::MoveUp)
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('d')) => Some(Action::PageDown),
+        (KeyModifiers::CONTROL, KeyCode::Char('u')) => Some(Action::PageUp),
+        (KeyModifiers::NONE, KeyCode::Char('g')) | (KeyModifiers::NONE, KeyCode::Home) => {
+            Some(Action::GoToTop)
+        }
+        (KeyModifiers::SHIFT, KeyCode::Char('G')) | (KeyModifiers::NONE, KeyCode::End) => {
+            Some(Action::GoToBottom)
+        }
+        (KeyModifiers::NONE, KeyCode::Enter) => Some(Action::Checkout),
+        (KeyModifiers::NONE, KeyCode::Char('d')) => Some(Action::DeleteBranch),
+        (KeyModifiers::SHIFT, KeyCode::Char('D')) => Some(Action::DeleteMergedBranches),
+        (KeyModifiers::NONE, KeyCode::Char('v')) => Some(Action::ReviewBranch),
+        (KeyModifiers::NONE, KeyCode::Char('w')) => Some(Action::WorktreeCreate),
+        (KeyModifiers::SHIFT, KeyCode::Char('W')) => Some(Action::WorktreeRemove),
         (KeyModifiers::NONE, KeyCode::Esc) | (KeyModifiers::NONE, KeyCode::Char('q')) => {
             Some(Action::Cancel)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,9 +63,10 @@ fn main() -> Result<()> {
         })?;
         app.perf.record("draw", draw_started.elapsed());
 
-        // Check if async fetch/push has completed
+        // Check if async fetch/push/review has completed
         app.update_fetch_status();
         app.update_push_status();
+        app.update_review_status();
 
         // Auto-refresh check
         app.check_auto_refresh();

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -63,6 +63,14 @@ fn handle_scroll(app: &mut App, delta: i32, x: u16, y: u16) {
             };
             dispatch(app, action);
         }
+        AppMode::BranchList { .. } => {
+            let action = if delta > 0 {
+                Action::MoveDown
+            } else {
+                Action::MoveUp
+            };
+            dispatch(app, action);
+        }
         AppMode::Normal | AppMode::FileSelect { .. } => {
             let layout = app.layout;
             if contains(layout.commit_detail, x, y) {
@@ -108,6 +116,22 @@ fn handle_click(app: &mut App, x: u16, y: u16) {
     match &app.mode {
         AppMode::Help | AppMode::Error { .. } => {
             dispatch(app, Action::Cancel);
+        }
+        AppMode::BranchList { rows, .. } => {
+            let row_count = rows.len();
+            if contains(app.layout.graph, x, y) {
+                let Some(row) = inner_row(app.layout.graph, y) else {
+                    return;
+                };
+                let idx = app.branch_list_scroll as usize + row as usize;
+                if idx >= row_count {
+                    return;
+                }
+                app.branch_list_move(idx);
+                if is_double {
+                    dispatch(app, Action::Checkout);
+                }
+            }
         }
         AppMode::Normal | AppMode::FileSelect { .. } => {
             let layout = app.layout;

--- a/src/ui/branch_list.rs
+++ b/src/ui/branch_list.rs
@@ -12,9 +12,10 @@ use unicode_width::UnicodeWidthStr;
 use crate::git::BranchTriageRow;
 
 use super::commit_detail::relative_time;
-use super::{render_placeholder_block, MIN_WIDGET_HEIGHT, MIN_WIDGET_WIDTH};
+use super::{render_placeholder_block, MIN_WIDGET_HEIGHT, MIN_WIDGET_WIDTH, ROW_SELECTION_BG};
 
-const NAME_WIDTH: usize = 28;
+const MIN_NAME_WIDTH: usize = 12;
+const MAX_NAME_WIDTH: usize = 40;
 const STATUS_WIDTH: usize = 12;
 
 /// Scroll offset that keeps the selected row visible
@@ -71,11 +72,25 @@ impl<'a> BranchListWidget<'a> {
         format!("{}…", result)
     }
 
+    /// Name column width fitting the longest branch name, clamped so one
+    /// long name doesn't eat the subject column on narrow terminals
+    fn name_width(&self, inner_width: usize) -> usize {
+        let longest = self
+            .rows
+            .iter()
+            .map(|row| row.name.width())
+            .max()
+            .unwrap_or(MIN_NAME_WIDTH);
+        let max_for_terminal = MAX_NAME_WIDTH.min(inner_width.saturating_sub(STATUS_WIDTH + 6));
+        longest.clamp(MIN_NAME_WIDTH, max_for_terminal.max(MIN_NAME_WIDTH))
+    }
+
     fn build_line(
         &self,
         row: &BranchTriageRow,
         is_selected: bool,
         inner_width: usize,
+        name_width: usize,
     ) -> Line<'static> {
         let mut spans: Vec<Span> = Vec::new();
 
@@ -95,8 +110,8 @@ impl<'a> BranchListWidget<'a> {
         }
 
         // Branch name
-        let name = Self::truncate(&row.name, NAME_WIDTH);
-        let name_pad = NAME_WIDTH.saturating_sub(name.width()) + 1;
+        let name = Self::truncate(&row.name, name_width);
+        let name_pad = name_width.saturating_sub(name.width()) + 1;
         let name_style = if row.is_head {
             Style::default()
                 .fg(Color::Green)
@@ -136,12 +151,12 @@ impl<'a> BranchListWidget<'a> {
             " ".repeat(STATUS_WIDTH.saturating_sub(status_width) + 1),
         ));
 
-        // Right-aligned relative time; subject fills the middle
+        // Right-aligned relative time; subject fills the middle.
+        // On narrow terminals the date is dropped first, then the subject.
         let date = relative_time(row.last_commit);
-        let used: usize = 1 + 2 + NAME_WIDTH + 1 + STATUS_WIDTH + 1;
-        let subject_budget = inner_width
-            .saturating_sub(used)
-            .saturating_sub(date.width() + 2);
+        let used: usize = 1 + 2 + name_width + 1 + STATUS_WIDTH + 1;
+        let remaining = inner_width.saturating_sub(used);
+        let subject_budget = remaining.saturating_sub(date.width() + 2);
         if subject_budget > 4 {
             let subject = Self::truncate(&row.subject, subject_budget);
             let subject_width = subject.width();
@@ -150,11 +165,14 @@ impl<'a> BranchListWidget<'a> {
                 " ".repeat(subject_budget.saturating_sub(subject_width) + 2),
             ));
             spans.push(Span::styled(date, Style::default().fg(Color::DarkGray)));
+        } else if remaining > 4 {
+            let subject = Self::truncate(&row.subject, remaining);
+            spans.push(Span::styled(subject, Style::default().fg(Color::DarkGray)));
         }
 
         let mut line = Line::from(spans);
         if is_selected {
-            line = line.style(Style::default().bg(Color::Rgb(40, 44, 62)));
+            line = line.style(Style::default().bg(ROW_SELECTION_BG));
         }
         line
     }
@@ -174,12 +192,24 @@ impl<'a> Widget for BranchListWidget<'a> {
         let block = super::pane_block(&title, true);
 
         let inner_width = area.width.saturating_sub(2) as usize;
-        let lines: Vec<Line> = self
-            .rows
-            .iter()
-            .enumerate()
-            .map(|(idx, row)| self.build_line(row, idx == self.selected, inner_width))
-            .collect();
+        let name_width = self.name_width(inner_width);
+        let lines: Vec<Line> = if self.rows.is_empty() {
+            vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    "  No local branches.",
+                    Style::default().fg(Color::DarkGray),
+                )),
+            ]
+        } else {
+            self.rows
+                .iter()
+                .enumerate()
+                .map(|(idx, row)| {
+                    self.build_line(row, idx == self.selected, inner_width, name_width)
+                })
+                .collect()
+        };
 
         let paragraph = Paragraph::new(lines).block(block).scroll((self.scroll, 0));
         Widget::render(paragraph, area, buf);

--- a/src/ui/branch_list.rs
+++ b/src/ui/branch_list.rs
@@ -1,0 +1,187 @@
+//! Branch triage list widget (full-screen, opened with B)
+
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Paragraph, Widget},
+};
+use unicode_width::UnicodeWidthStr;
+
+use crate::git::BranchTriageRow;
+
+use super::commit_detail::relative_time;
+use super::{render_placeholder_block, MIN_WIDGET_HEIGHT, MIN_WIDGET_WIDTH};
+
+const NAME_WIDTH: usize = 28;
+const STATUS_WIDTH: usize = 12;
+
+/// Scroll offset that keeps the selected row visible
+pub fn scroll_offset(selected: usize, row_count: usize, area: Rect) -> u16 {
+    let visible_height = area.height.saturating_sub(2);
+    if visible_height == 0 {
+        return 0;
+    }
+    let selected = selected as u16;
+    let max_scroll = (row_count as u16).saturating_sub(visible_height);
+    if selected >= visible_height {
+        (selected - visible_height / 2).min(max_scroll)
+    } else {
+        0
+    }
+}
+
+pub struct BranchListWidget<'a> {
+    rows: &'a [BranchTriageRow],
+    selected: usize,
+    base_name: Option<&'a str>,
+    scroll: u16,
+}
+
+impl<'a> BranchListWidget<'a> {
+    pub fn new(
+        rows: &'a [BranchTriageRow],
+        selected: usize,
+        base_name: Option<&'a str>,
+        scroll: u16,
+    ) -> Self {
+        Self {
+            rows,
+            selected,
+            base_name,
+            scroll,
+        }
+    }
+
+    fn truncate(text: &str, max_width: usize) -> String {
+        if text.width() <= max_width {
+            return text.to_string();
+        }
+        let mut result = String::new();
+        let mut width = 1; // for the trailing ellipsis
+        for c in text.chars() {
+            let w = unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+            if width + w > max_width {
+                break;
+            }
+            result.push(c);
+            width += w;
+        }
+        format!("{}…", result)
+    }
+
+    fn build_line(
+        &self,
+        row: &BranchTriageRow,
+        is_selected: bool,
+        inner_width: usize,
+    ) -> Line<'static> {
+        let mut spans: Vec<Span> = Vec::new();
+
+        if is_selected {
+            spans.push(Span::styled("▌", Style::default().fg(Color::Cyan)));
+        } else {
+            spans.push(Span::raw(" "));
+        }
+
+        // Flag column: HEAD or worktree
+        if row.is_head {
+            spans.push(Span::styled("◉ ", Style::default().fg(Color::Green)));
+        } else if row.worktree_path.is_some() {
+            spans.push(Span::styled("⌂ ", Style::default().fg(Color::Magenta)));
+        } else {
+            spans.push(Span::raw("  "));
+        }
+
+        // Branch name
+        let name = Self::truncate(&row.name, NAME_WIDTH);
+        let name_pad = NAME_WIDTH.saturating_sub(name.width()) + 1;
+        let name_style = if row.is_head {
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().add_modifier(Modifier::BOLD)
+        };
+        spans.push(Span::styled(name, name_style));
+        spans.push(Span::raw(" ".repeat(name_pad)));
+
+        // Status: base / merged / ahead-behind
+        let (status_spans, status_width) = if row.is_base {
+            (
+                vec![Span::styled("base", Style::default().fg(Color::Blue))],
+                4,
+            )
+        } else if row.merged {
+            (
+                vec![Span::styled("merged", Style::default().fg(Color::Magenta))],
+                6,
+            )
+        } else {
+            let ahead = format!("↑{}", row.ahead);
+            let behind = format!("↓{}", row.behind);
+            let width = ahead.width() + 1 + behind.width();
+            (
+                vec![
+                    Span::styled(ahead, Style::default().fg(Color::Green)),
+                    Span::raw(" "),
+                    Span::styled(behind, Style::default().fg(Color::Red)),
+                ],
+                width,
+            )
+        };
+        spans.extend(status_spans);
+        spans.push(Span::raw(
+            " ".repeat(STATUS_WIDTH.saturating_sub(status_width) + 1),
+        ));
+
+        // Right-aligned relative time; subject fills the middle
+        let date = relative_time(row.last_commit);
+        let used: usize = 1 + 2 + NAME_WIDTH + 1 + STATUS_WIDTH + 1;
+        let subject_budget = inner_width
+            .saturating_sub(used)
+            .saturating_sub(date.width() + 2);
+        if subject_budget > 4 {
+            let subject = Self::truncate(&row.subject, subject_budget);
+            let subject_width = subject.width();
+            spans.push(Span::styled(subject, Style::default().fg(Color::DarkGray)));
+            spans.push(Span::raw(
+                " ".repeat(subject_budget.saturating_sub(subject_width) + 2),
+            ));
+            spans.push(Span::styled(date, Style::default().fg(Color::DarkGray)));
+        }
+
+        let mut line = Line::from(spans);
+        if is_selected {
+            line = line.style(Style::default().bg(Color::Rgb(40, 44, 62)));
+        }
+        line
+    }
+}
+
+impl<'a> Widget for BranchListWidget<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if area.width < MIN_WIDGET_WIDTH || area.height < MIN_WIDGET_HEIGHT {
+            render_placeholder_block(area, buf);
+            return;
+        }
+
+        let title = match self.base_name {
+            Some(base) => format!("Branches ({}) · vs {}", self.rows.len(), base),
+            None => format!("Branches ({})", self.rows.len()),
+        };
+        let block = super::pane_block(&title, true);
+
+        let inner_width = area.width.saturating_sub(2) as usize;
+        let lines: Vec<Line> = self
+            .rows
+            .iter()
+            .enumerate()
+            .map(|(idx, row)| self.build_line(row, idx == self.selected, inner_width))
+            .collect();
+
+        let paragraph = Paragraph::new(lines).block(block).scroll((self.scroll, 0));
+        Widget::render(paragraph, area, buf);
+    }
+}

--- a/src/ui/commit_detail.rs
+++ b/src/ui/commit_detail.rs
@@ -9,13 +9,13 @@ use ratatui::{
 };
 use unicode_width::UnicodeWidthStr;
 
-use crate::app::{App, AppMode, FocusedPane};
+use crate::app::{App, AppMode, DiffSource, FocusedPane};
 use crate::git::{FileChangeKind, StageState};
 
 use super::{render_placeholder_block, MIN_WIDGET_HEIGHT, MIN_WIDGET_WIDTH};
 
 /// Human-friendly relative time like "3 days ago"
-fn relative_time(ts: chrono::DateTime<chrono::Local>) -> String {
+pub(crate) fn relative_time(ts: chrono::DateTime<chrono::Local>) -> String {
     let secs = chrono::Local::now().signed_duration_since(ts).num_seconds();
     if secs < 0 {
         return "in the future".to_string();
@@ -177,6 +177,20 @@ impl CommitDetailWidget {
             lines.push(Line::from(spans));
         }
 
+        // Worktrees checked out from branches on this commit
+        for name in &node.branch_names {
+            if let Some(worktree) = app.worktree_for_branch(name) {
+                lines.push(Line::from(vec![
+                    // "Worktree" fills the 8-char label column; keep one space
+                    Self::metadata_label("Worktree"),
+                    Span::styled(
+                        format!(" ⌂ {}", worktree.path.display()),
+                        Style::default().fg(Color::Magenta),
+                    ),
+                ]));
+            }
+        }
+
         lines.push(Line::from(Span::styled(
             " ".to_string() + &"─".repeat(28),
             Style::default().fg(Color::DarkGray),
@@ -276,11 +290,26 @@ impl FileListWidget {
             _ => None,
         };
 
-        let stage_states = app.is_uncommitted_selected().then_some(&app.stage_states);
+        // Branch review shows the precomputed range diff instead of the
+        // selection's diff
+        let review_diff = match &app.mode {
+            AppMode::FileSelect {
+                source: DiffSource::Range { .. },
+                ..
+            } => app.review_diff.as_ref(),
+            _ => None,
+        };
+
+        let stage_states =
+            (review_diff.is_none() && app.is_uncommitted_selected()).then_some(&app.stage_states);
 
         // Prefer cached data (even if stale) over a loading indicator so that
         // auto-refresh doesn't cause the file list to flicker.
-        let Some(diff) = app.cached_diff() else {
+        let diff = if let Some(diff) = review_diff {
+            diff
+        } else if let Some(diff) = app.cached_diff() {
+            diff
+        } else {
             if app.is_diff_loading() {
                 return FileListContent::Loading;
             }

--- a/src/ui/commit_detail.rs
+++ b/src/ui/commit_detail.rs
@@ -261,6 +261,8 @@ pub struct FileListWidget {
     content: FileListContent,
     file_scroll: u16,
     focused: bool,
+    /// Base branch name while reviewing (changes the pane title)
+    review_base: Option<String>,
 }
 
 impl FileListWidget {
@@ -269,10 +271,18 @@ impl FileListWidget {
             AppMode::FileSelect { selected_index, .. } => *selected_index as u16,
             _ => 0,
         };
+        let review_base = match &app.mode {
+            AppMode::FileSelect {
+                source: DiffSource::Range { base_name, .. },
+                ..
+            } => Some(base_name.clone()),
+            _ => None,
+        };
         Self {
             content: Self::build_content(app),
             file_scroll,
             focused: matches!(app.mode, AppMode::FileSelect { .. }),
+            review_base,
         }
     }
 
@@ -402,9 +412,10 @@ impl FileListWidget {
                 let mut lines = Vec::with_capacity(rows.len() + 3);
 
                 // Header row
+                let plural = if header.total_files == 1 { "" } else { "s" };
                 let mut spans = vec![
                     Span::styled(
-                        format!(" {} files changed", header.total_files),
+                        format!(" {} file{} changed", header.total_files, plural),
                         Style::default().add_modifier(Modifier::BOLD),
                     ),
                     Span::raw("  "),
@@ -554,9 +565,11 @@ impl Widget for FileListWidget {
             return;
         }
 
-        let title = match self.file_count() {
-            Some(count) => format!("Changed Files ({})", count),
-            None => "Changed Files".to_string(),
+        let title = match (&self.review_base, self.file_count()) {
+            (Some(base), Some(count)) => format!("Review vs {} ({})", base, count),
+            (Some(base), None) => format!("Review vs {}", base),
+            (None, Some(count)) => format!("Changed Files ({})", count),
+            (None, None) => "Changed Files".to_string(),
         };
         let block = super::pane_block(&title, self.focused);
 

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -5,7 +5,7 @@ use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget},
+    widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget, Wrap},
 };
 
 /// Truncate a string to fit within max_width, adding "..." if needed
@@ -107,6 +107,63 @@ impl<'a> Widget for ConfirmDialog<'a> {
         ];
 
         let paragraph = Paragraph::new(lines).block(block);
+        Widget::render(paragraph, area, buf);
+    }
+}
+
+/// Error dialog: full message with wrapping (the status bar clips long
+/// git errors to one line, which made real failures unreadable)
+pub struct ErrorDialog<'a> {
+    message: &'a str,
+}
+
+impl<'a> ErrorDialog<'a> {
+    pub fn new(message: &'a str) -> Self {
+        Self { message }
+    }
+
+    /// Rows needed to show the whole message at the given dialog width
+    pub fn required_height(message: &str, width: u16) -> u16 {
+        let inner = width.saturating_sub(4).max(1) as usize;
+        let text_rows = message
+            .lines()
+            .map(|line| line.chars().count().max(1).div_ceil(inner))
+            .sum::<usize>() as u16;
+        // borders + padding row + hint row
+        text_rows + 4
+    }
+}
+
+impl<'a> Widget for ErrorDialog<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        Clear.render(area, buf);
+
+        let block = Block::default()
+            .title(" Error ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red))
+            .border_type(BorderType::Rounded)
+            .style(Style::default().bg(Color::Black));
+
+        let mut lines: Vec<Line> = self
+            .message
+            .lines()
+            .map(|line| {
+                Line::from(Span::styled(
+                    line.to_string(),
+                    Style::default().fg(Color::White),
+                ))
+            })
+            .collect();
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Esc/Enter: close",
+            Style::default().fg(Color::DarkGray),
+        )));
+
+        let paragraph = Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false });
         Widget::render(paragraph, area, buf);
     }
 }

--- a/src/ui/graph_view.rs
+++ b/src/ui/graph_view.rs
@@ -5,7 +5,7 @@ use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{List, ListItem, ListState, StatefulWidget},
+    widgets::{List, ListItem, Widget},
 };
 use unicode_width::UnicodeWidthChar;
 
@@ -15,9 +15,7 @@ use crate::{
     graph::colors::get_color_by_index,
 };
 
-use super::{render_placeholder_block, MIN_WIDGET_HEIGHT, MIN_WIDGET_WIDTH};
-
-const ROW_SELECTION_BG: Color = Color::Rgb(40, 44, 62);
+use super::{render_placeholder_block, MIN_WIDGET_HEIGHT, MIN_WIDGET_WIDTH, ROW_SELECTION_BG};
 
 fn with_row_selection(style: Style, is_row_selected: bool) -> Style {
     if is_row_selected {
@@ -83,10 +81,14 @@ pub struct GraphViewWidget<'a> {
 }
 
 impl<'a> GraphViewWidget<'a> {
-    pub fn new(app: &App, width: u16) -> Self {
+    /// Build list items for the visible window only. The caller must have
+    /// synced the scroll offset (`App::clamp_graph_offset`) beforehand;
+    /// building all ~500 rows every frame dominated the render cost.
+    pub fn new(app: &App, width: u16, height: u16) -> Self {
         let max_lane = app.graph_layout.max_lane;
         // Actual width minus borders
         let inner_width = width.saturating_sub(2) as usize;
+        let viewport = height.saturating_sub(2) as usize;
 
         // Get the currently selected branch name
         let selected_branch_name = app.selected_branch_name();
@@ -98,13 +100,13 @@ impl<'a> GraphViewWidget<'a> {
             .filter_map(|w| w.branch.as_deref())
             .collect();
 
-        let items: Vec<ListItem> = app
-            .graph_layout
-            .nodes
+        let offset = app.graph_list_state.offset();
+        let end = (offset + viewport).min(app.graph_layout.nodes.len());
+        let items: Vec<ListItem> = app.graph_layout.nodes[offset..end]
             .iter()
             .enumerate()
-            .map(|(idx, node)| {
-                let is_selected = app.graph_list_state.selected() == Some(idx);
+            .map(|(i, node)| {
+                let is_selected = app.graph_list_state.selected() == Some(offset + i);
                 let line = render_graph_line(
                     node,
                     max_lane,
@@ -120,9 +122,14 @@ impl<'a> GraphViewWidget<'a> {
         let focused = matches!(app.mode, crate::app::AppMode::Normal)
             && app.focused_pane == crate::app::FocusedPane::Graph;
 
+        let node_count = app.graph_layout.nodes.len();
         let position = (
-            app.graph_list_state.selected().map_or(0, |idx| idx + 1),
-            app.graph_layout.nodes.len(),
+            if node_count == 0 {
+                0
+            } else {
+                app.graph_list_state.selected().map_or(0, |idx| idx + 1)
+            },
+            node_count,
         );
 
         Self {
@@ -578,10 +585,8 @@ fn render_graph_line<'a>(
     Line::from(spans)
 }
 
-impl<'a> StatefulWidget for GraphViewWidget<'a> {
-    type State = ListState;
-
-    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+impl<'a> Widget for GraphViewWidget<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
         if area.width < MIN_WIDGET_WIDTH || area.height < MIN_WIDGET_HEIGHT {
             render_placeholder_block(area, buf);
             return;
@@ -590,8 +595,26 @@ impl<'a> StatefulWidget for GraphViewWidget<'a> {
         let title = format!("Commits {}/{}", self.position.0, self.position.1);
         let block = super::pane_block(&title, self.focused);
 
+        if self.position.1 == 0 {
+            let placeholder = ratatui::widgets::Paragraph::new(vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    "  No commits yet.",
+                    Style::default().fg(Color::DarkGray),
+                )),
+                Line::from(Span::styled(
+                    "  Edit files, then press Space to stage and 'c' to commit.",
+                    Style::default().fg(Color::DarkGray),
+                )),
+            ])
+            .block(block);
+            Widget::render(placeholder, area, buf);
+            return;
+        }
+
+        // Items are already windowed to the viewport; render from the top
         let list = List::new(self.items).block(block);
 
-        StatefulWidget::render(list, area, buf, state);
+        Widget::render(list, area, buf);
     }
 }

--- a/src/ui/graph_view.rs
+++ b/src/ui/graph_view.rs
@@ -91,6 +91,13 @@ impl<'a> GraphViewWidget<'a> {
         // Get the currently selected branch name
         let selected_branch_name = app.selected_branch_name();
 
+        // Branches checked out in linked worktrees (shown with a ⌂ marker)
+        let worktree_branches: std::collections::HashSet<&str> = app
+            .worktrees
+            .iter()
+            .filter_map(|w| w.branch.as_deref())
+            .collect();
+
         let items: Vec<ListItem> = app
             .graph_layout
             .nodes
@@ -104,6 +111,7 @@ impl<'a> GraphViewWidget<'a> {
                     is_selected,
                     inner_width,
                     selected_branch_name,
+                    &worktree_branches,
                 );
                 ListItem::new(line)
             })
@@ -136,6 +144,7 @@ fn optimize_branch_display(
     color_index: usize,
     selected_branch_name: Option<&str>,
     is_row_selected: bool,
+    worktree_branches: &std::collections::HashSet<&str>,
 ) -> Vec<(String, Style)> {
     use std::collections::HashSet;
 
@@ -208,14 +217,17 @@ fn optimize_branch_display(
             }
             result.push((make_label(name, None), make_style(name)));
         } else {
-            // Local branch: check for matching remote
+            // Local branch: check for worktree checkout and matching remote
             let remote_name = format!("origin/{}", name);
-            let suffix = if remote_branches.contains(remote_name.as_str()) {
-                Some("↔ origin")
-            } else {
-                None
-            };
-            result.push((make_label(name, suffix), make_style(name)));
+            let mut suffix_parts: Vec<&str> = Vec::new();
+            if worktree_branches.contains(name.as_str()) {
+                suffix_parts.push("⌂");
+            }
+            if remote_branches.contains(remote_name.as_str()) {
+                suffix_parts.push("↔ origin");
+            }
+            let suffix = (!suffix_parts.is_empty()).then(|| suffix_parts.join(" "));
+            result.push((make_label(name, suffix.as_deref()), make_style(name)));
         }
     }
 
@@ -356,6 +368,7 @@ fn render_graph_line<'a>(
     is_selected: bool,
     total_width: usize,
     selected_branch_name: Option<&str>,
+    worktree_branches: &std::collections::HashSet<&str>,
 ) -> Line<'a> {
     let mut spans: Vec<Span> = Vec::new();
 
@@ -488,6 +501,7 @@ fn render_graph_line<'a>(
         node.color_index,
         selected_branch_name,
         is_selected,
+        worktree_branches,
     );
 
     // === Right-aligned: date author hash (fixed width) ===

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -129,6 +129,46 @@ fn help_lines() -> Vec<Line<'static>> {
             Span::styled("  W          ", key_style),
             Span::styled("Remove worktree of selected branch", desc_style),
         ]),
+        Line::from(""),
+        Line::from(Span::styled("Branch List (B)", header_style)),
+        Line::from(vec![
+            Span::styled("  Enter      ", key_style),
+            Span::styled("Checkout selected branch", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  d          ", key_style),
+            Span::styled("Delete selected branch", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  D          ", key_style),
+            Span::styled("Delete ALL merged branches", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  v / w / W  ", key_style),
+            Span::styled("Review / create / remove worktree", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  Esc / B    ", key_style),
+            Span::styled("Close the list", desc_style),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled("Diff View", header_style)),
+        Line::from(vec![
+            Span::styled("  n / N      ", key_style),
+            Span::styled("Next / previous file", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  ] / [      ", key_style),
+            Span::styled("Next / previous hunk", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  h / l / 0  ", key_style),
+            Span::styled("Pan horizontally / back to start", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  C-f / C-b  ", key_style),
+            Span::styled("Page down / up", desc_style),
+        ]),
         // TODO: merge and rebase will be implemented in the future
         // Line::from(vec![
         //     Span::styled("  m          ", key_style),

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -111,6 +111,24 @@ fn help_lines() -> Vec<Line<'static>> {
             Span::styled("  p          ", key_style),
             Span::styled("Push current branch to origin", desc_style),
         ]),
+        Line::from(""),
+        Line::from(Span::styled("Branches / Worktrees", header_style)),
+        Line::from(vec![
+            Span::styled("  B          ", key_style),
+            Span::styled("Branch list (triage / cleanup)", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  v          ", key_style),
+            Span::styled("Review branch against base (main)", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  w          ", key_style),
+            Span::styled("Create worktree for selected branch", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  W          ", key_style),
+            Span::styled("Remove worktree of selected branch", desc_style),
+        ]),
         // TODO: merge and rebase will be implemented in the future
         // Line::from(vec![
         //     Span::styled("  m          ", key_style),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -43,8 +43,12 @@ const MIN_HEIGHT: u16 = 6;
 pub const MIN_WIDGET_WIDTH: u16 = 12;
 pub const MIN_WIDGET_HEIGHT: u16 = 3;
 
+/// Background color of the selected row in list-style panes
+pub(crate) const ROW_SELECTION_BG: Color = Color::Rgb(40, 44, 62);
+
 /// Width threshold for switching the detail area to a vertical layout
-const VERTICAL_LAYOUT_THRESHOLD: u16 = 56;
+/// (below this, two side-by-side panes get too cramped to read a hash line)
+const VERTICAL_LAYOUT_THRESHOLD: u16 = 70;
 
 /// Border style for a pane depending on focus
 pub fn pane_border_style(focused: bool) -> Style {
@@ -266,10 +270,10 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     app.files_pane_scroll = files_widget.scroll_offset(files_area);
 
     // Render widgets
-    frame.render_stateful_widget(
-        GraphViewWidget::new(app, graph_area.width),
+    app.clamp_graph_offset(graph_area.height.saturating_sub(2) as usize);
+    frame.render_widget(
+        GraphViewWidget::new(app, graph_area.width, graph_area.height),
         graph_area,
-        &mut app.graph_list_state,
     );
     frame.render_widget(commit_widget, commit_area);
     frame.render_widget(files_widget, files_area);
@@ -300,7 +304,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     // Popups
     match &app.mode {
         AppMode::Help => {
-            let popup_area = centered_rect(60, 70, area);
+            let popup_area = help_rect(area);
             let viewport_height = popup_area.height.saturating_sub(2) as usize;
             let line_count = HelpPopup::line_count();
             let max_scroll = line_count.saturating_sub(viewport_height) as u16;
@@ -334,15 +338,52 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
             );
         }
         AppMode::Input { title, input, .. } => {
-            let popup_area = centered_rect(50, 20, area);
+            let popup_area = dialog_rect(50, 6, area);
             frame.render_widget(InputDialog::new(title, input), popup_area);
         }
         AppMode::Confirm { message, .. } => {
-            let popup_area = centered_rect(50, 20, area);
+            let popup_area = dialog_rect(50, 6, area);
             frame.render_widget(ConfirmDialog::new(message), popup_area);
+        }
+        AppMode::Error { message } => {
+            let width_percent = 60;
+            let width = area.width * width_percent / 100;
+            let height = dialog::ErrorDialog::required_height(message, width);
+            let popup_area = dialog_rect(width_percent, height, area);
+            frame.render_widget(dialog::ErrorDialog::new(message), popup_area);
         }
         _ => {}
     }
+}
+
+/// Centered dialog rect with a fixed row height (percentage heights cut off
+/// the y/n hint row on short terminals)
+fn dialog_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
+    let clamped_height = height.min(area.height.saturating_sub(2)).max(3);
+    let y = area.y + (area.height.saturating_sub(clamped_height)) / 2;
+
+    let horizontal = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(area);
+
+    Rect::new(horizontal[1].x, y, horizontal[1].width, clamped_height)
+}
+
+/// Help popup rect: percentage-based but clamped to a readable width range
+/// so lines are not truncated on narrow terminals
+fn help_rect(area: Rect) -> Rect {
+    let width = (area.width * 60 / 100)
+        .max(52)
+        .min(area.width.saturating_sub(2));
+    let height = (area.height * 70 / 100).max(12).min(area.height);
+    let x = area.x + (area.width.saturating_sub(width)) / 2;
+    let y = area.y + (area.height.saturating_sub(height)) / 2;
+    Rect::new(x, y, width, height)
 }
 
 /// Render branch info popup when multiple branches exist on selected node
@@ -385,27 +426,6 @@ fn render_branch_info_popup(frame: &mut Frame, app: &App, graph_area: Rect) {
         BranchInfoPopup::new(&selected_branches, app.selected_branch_name()),
         popup_area,
     );
-}
-
-/// Calculate a centered rectangle
-fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
-    let popup_layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage((100 - percent_y) / 2),
-            Constraint::Percentage(percent_y),
-            Constraint::Percentage((100 - percent_y) / 2),
-        ])
-        .split(area);
-
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage((100 - percent_x) / 2),
-            Constraint::Percentage(percent_x),
-            Constraint::Percentage((100 - percent_x) / 2),
-        ])
-        .split(popup_layout[1])[1]
 }
 
 /// Calculate a bottom-aligned rectangle (for dropdowns)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 //! UI components
 
+pub mod branch_list;
 pub mod commit_detail;
 pub mod dialog;
 pub mod file_diff_view;
@@ -23,6 +24,7 @@ use ratatui::{
 use crate::app::{App, AppMode, InputAction};
 
 use self::{
+    branch_list::BranchListWidget,
     commit_detail::{CommitDetailWidget, FileListWidget},
     dialog::{BranchInfoPopup, ConfirmDialog, InputDialog},
     file_diff_view::FileDiffViewWidget,
@@ -182,6 +184,46 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         app.layout.status_bar = vertical[1];
         let status_bar = StatusBar::new(app);
         app.status_hints = status_bar.hint_regions(vertical[1]);
+        frame.render_widget(status_bar, vertical[1]);
+        return;
+    }
+
+    // BranchList mode: full-screen branch triage view
+    if let AppMode::BranchList { selected, rows, .. } = &app.mode {
+        let (selected, row_count) = (*selected, rows.len());
+        let vertical = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(0), Constraint::Length(1)])
+            .split(area);
+
+        let scroll = branch_list::scroll_offset(selected, row_count, vertical[0]);
+        app.branch_list_scroll = scroll;
+        // Record the list area for mouse hit-testing (reuses the graph slot)
+        app.layout.graph = vertical[0];
+        app.layout.status_bar = vertical[1];
+
+        let status_bar = StatusBar::new(app);
+        app.status_hints = status_bar.hint_regions(vertical[1]);
+
+        if let AppMode::BranchList {
+            selected,
+            rows,
+            base_name,
+        } = &app.mode
+        {
+            frame.render_widget(
+                BranchListWidget::new(rows, *selected, base_name.as_deref(), scroll),
+                vertical[0],
+            );
+        }
+        render_scrollbar(
+            frame,
+            vertical[0],
+            row_count,
+            vertical[0].height.saturating_sub(2) as usize,
+            scroll as usize,
+        );
+
         frame.render_widget(status_bar, vertical[1]);
         return;
     }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -13,7 +13,7 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::action::Action;
-use crate::app::{App, AppMode, FocusedPane, InputAction};
+use crate::app::{App, AppMode, DiffSource, FocusedPane, InputAction};
 
 struct Hint {
     key: &'static str,
@@ -112,6 +112,7 @@ impl StatusBar {
                     hints.push(Hint::new("Space", "files", Some(Action::EnterFileSelect)));
                     hints.push(Hint::new("c", "commit", Some(Action::CommitDialog)));
                     hints.push(Hint::new("p", "push", Some(Action::Push)));
+                    hints.push(Hint::new("B", "branches", Some(Action::OpenBranchList)));
                     hints.push(Hint::new("?", "help", Some(Action::ToggleHelp)));
                     hints.push(Hint::new("q", "quit", Some(Action::Quit)));
                 }
@@ -159,11 +160,28 @@ impl StatusBar {
                 prefix.push(Span::raw("  "));
                 hints.push(Hint::new("Esc/Enter", "close", Some(Action::Cancel)));
             }
-            AppMode::FileSelect { .. } => {
-                mode_label = Some(" FILES ");
+            AppMode::FileSelect { source, .. } => {
+                if let DiffSource::Range {
+                    base_name,
+                    head_name,
+                    ..
+                } = source
+                {
+                    mode_label = Some(" REVIEW ");
+                    prefix.push(Span::styled(
+                        format!(" {}…{} ", base_name, head_name),
+                        Style::default()
+                            .fg(Color::Black)
+                            .bg(Color::Magenta)
+                            .add_modifier(Modifier::BOLD),
+                    ));
+                    prefix.push(Span::raw(" "));
+                } else {
+                    mode_label = Some(" FILES ");
+                }
                 hints.push(Hint::new("j/k", "select", None));
                 hints.push(Hint::new("Enter", "diff", Some(Action::OpenFileDiff)));
-                if app.is_uncommitted_selected() {
+                if matches!(source, DiffSource::Selection) && app.is_uncommitted_selected() {
                     hints.push(Hint::new("s", "stage", Some(Action::StageToggle)));
                     hints.push(Hint::new("a", "all", Some(Action::StageAll)));
                     hints.push(Hint::new("u", "none", Some(Action::UnstageAll)));
@@ -171,12 +189,41 @@ impl StatusBar {
                 }
                 hints.push(Hint::new("Esc", "back", Some(Action::Cancel)));
             }
-            AppMode::FileDiff { .. } => {
+            AppMode::FileDiff { source, .. } => {
                 mode_label = Some(" DIFF ");
+                if let DiffSource::Range {
+                    base_name,
+                    head_name,
+                    ..
+                } = source
+                {
+                    prefix.push(Span::styled(
+                        format!(" {}…{} ", base_name, head_name),
+                        Style::default()
+                            .fg(Color::Black)
+                            .bg(Color::Magenta)
+                            .add_modifier(Modifier::BOLD),
+                    ));
+                    prefix.push(Span::raw(" "));
+                }
                 hints.push(Hint::new("n/N", "file", Some(Action::NextFile)));
                 hints.push(Hint::new("]/[", "hunk", Some(Action::NextHunk)));
                 hints.push(Hint::new("j/k", "scroll", None));
                 hints.push(Hint::new("h/l", "pan", None));
+                hints.push(Hint::new("Esc", "back", Some(Action::Cancel)));
+            }
+            AppMode::BranchList { .. } => {
+                mode_label = Some(" BRANCHES ");
+                hints.push(Hint::new("j/k", "select", None));
+                hints.push(Hint::new("Enter", "checkout", Some(Action::Checkout)));
+                hints.push(Hint::new("v", "review", Some(Action::ReviewBranch)));
+                hints.push(Hint::new("w", "worktree", Some(Action::WorktreeCreate)));
+                hints.push(Hint::new("d", "delete", Some(Action::DeleteBranch)));
+                hints.push(Hint::new(
+                    "D",
+                    "prune merged",
+                    Some(Action::DeleteMergedBranches),
+                ));
                 hints.push(Hint::new("Esc", "back", Some(Action::Cancel)));
             }
         }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -122,21 +122,25 @@ impl StatusBar {
                 hints.push(Hint::new("j/k", "scroll", None));
                 hints.push(Hint::new("Esc/q", "close help", Some(Action::ToggleHelp)));
             }
-            AppMode::Input { action, .. } => {
+            AppMode::Input { action, input, .. } => {
                 mode_label = Some(" INPUT ");
-                if *action == InputAction::Search {
+                // Match count only once the user typed something; "No matches"
+                // on a green success badge before typing read as a bug
+                if *action == InputAction::Search && !input.is_empty() {
                     let count = app.search_match_count();
-                    let info = if count > 0 {
-                        format!(" {} matches ", count)
+                    let (info, bg) = if count > 0 {
+                        (format!(" {} matches ", count), Color::Green)
                     } else {
-                        " No matches ".to_string()
+                        (" No matches ".to_string(), Color::DarkGray)
+                    };
+                    let fg = if count > 0 {
+                        Color::Black
+                    } else {
+                        Color::White
                     };
                     prefix.push(Span::styled(
                         info,
-                        Style::default()
-                            .fg(Color::Black)
-                            .bg(Color::Green)
-                            .add_modifier(Modifier::BOLD),
+                        Style::default().fg(fg).bg(bg).add_modifier(Modifier::BOLD),
                     ));
                     prefix.push(Span::raw("  "));
                 }
@@ -148,16 +152,9 @@ impl StatusBar {
                 hints.push(Hint::new("y", "yes", Some(Action::Confirm)));
                 hints.push(Hint::new("n", "no", Some(Action::Cancel)));
             }
-            AppMode::Error { message } => {
+            AppMode::Error { .. } => {
+                // The full message is shown in the error dialog
                 mode_label = Some(" ERROR ");
-                prefix.push(Span::styled(
-                    format!(" {} ", message),
-                    Style::default()
-                        .fg(Color::White)
-                        .bg(Color::Red)
-                        .add_modifier(Modifier::BOLD),
-                ));
-                prefix.push(Span::raw("  "));
                 hints.push(Hint::new("Esc/Enter", "close", Some(Action::Cancel)));
             }
             AppMode::FileSelect { source, .. } => {
@@ -219,11 +216,7 @@ impl StatusBar {
                 hints.push(Hint::new("v", "review", Some(Action::ReviewBranch)));
                 hints.push(Hint::new("w", "worktree", Some(Action::WorktreeCreate)));
                 hints.push(Hint::new("d", "delete", Some(Action::DeleteBranch)));
-                hints.push(Hint::new(
-                    "D",
-                    "prune merged",
-                    Some(Action::DeleteMergedBranches),
-                ));
+                hints.push(Hint::new("D", "prune", Some(Action::DeleteMergedBranches)));
                 hints.push(Hint::new("Esc", "back", Some(Action::Cancel)));
             }
         }
@@ -273,7 +266,14 @@ impl Widget for StatusBar {
             .add_modifier(Modifier::BOLD);
 
         let mut spans = self.prefix.clone();
+        // Drop whole hints that don't fit instead of clipping mid-word
+        // (mirrors the hint_regions loop so clicks match what is shown)
+        let mut used = self.prefix_width();
         for hint in &self.hints {
+            if used + hint.width() > area.width {
+                break;
+            }
+            used += hint.width();
             spans.push(Span::styled(hint.key_text(), key_style));
             spans.push(Span::styled(hint.desc_text(), desc_style));
         }

--- a/tests/branch_triage_test.rs
+++ b/tests/branch_triage_test.rs
@@ -1,0 +1,162 @@
+use std::fs;
+use std::path::Path;
+
+use git2::{Oid, Repository, Signature};
+use keifu::git::{collect_triage, default_base_branch, CommitDiffInfo, WorktreeInfo};
+use tempfile::TempDir;
+
+fn init_repo_with_main() -> (TempDir, Repository) {
+    let tempdir = tempfile::tempdir().unwrap();
+    let repo = Repository::init(tempdir.path()).unwrap();
+
+    fs::write(tempdir.path().join("tracked.txt"), "tracked\n").unwrap();
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new("tracked.txt")).unwrap();
+    index.write().unwrap();
+    let tree_id = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    let signature = Signature::now("Test User", "test@example.com").unwrap();
+    repo.commit(Some("HEAD"), &signature, &signature, "initial", &tree, &[])
+        .unwrap();
+    drop(tree);
+
+    // Normalize the default branch name to "main" regardless of git config
+    let head_name = repo.head().unwrap().shorthand().unwrap().to_string();
+    if head_name != "main" {
+        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("main", &head_commit, false).unwrap();
+        drop(head_commit);
+        repo.set_head("refs/heads/main").unwrap();
+        repo.find_branch(&head_name, git2::BranchType::Local)
+            .unwrap()
+            .delete()
+            .unwrap();
+    }
+
+    (tempdir, repo)
+}
+
+fn commit_file(repo: &Repository, path: &str, contents: &str, message: &str) -> Oid {
+    let workdir = repo.workdir().unwrap();
+    fs::write(workdir.join(path), contents).unwrap();
+
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new(path)).unwrap();
+    index.write().unwrap();
+    let tree_id = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    let signature = Signature::now("Test User", "test@example.com").unwrap();
+    let parent = repo.head().unwrap().peel_to_commit().unwrap();
+    repo.commit(
+        Some("HEAD"),
+        &signature,
+        &signature,
+        message,
+        &tree,
+        &[&parent],
+    )
+    .unwrap()
+}
+
+#[test]
+fn default_base_branch_prefers_local_main() {
+    let (_tempdir, repo) = init_repo_with_main();
+
+    let (name, oid) = default_base_branch(&repo).unwrap();
+    assert_eq!(name, "main");
+    assert_eq!(oid, repo.head().unwrap().target().unwrap());
+}
+
+#[test]
+fn triage_marks_merged_and_ahead_branches() {
+    let (_tempdir, repo) = init_repo_with_main();
+    let base_commit = repo.head().unwrap().peel_to_commit().unwrap();
+
+    // Branch fully contained in main
+    repo.branch("merged-work", &base_commit, false).unwrap();
+
+    // Branch with an extra commit
+    repo.branch("feature", &base_commit, false).unwrap();
+    repo.set_head("refs/heads/feature").unwrap();
+    commit_file(&repo, "feature.txt", "feature\n", "feature work");
+
+    // Advance main by one commit so feature is also behind
+    repo.set_head("refs/heads/main").unwrap();
+    repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    commit_file(&repo, "main.txt", "main\n", "main work");
+
+    let (base_name, rows) = collect_triage(&repo, &[]).unwrap();
+    assert_eq!(base_name.as_deref(), Some("main"));
+
+    let merged = rows.iter().find(|r| r.name == "merged-work").unwrap();
+    assert!(merged.merged);
+    assert_eq!(merged.ahead, 0);
+    assert_eq!(merged.behind, 1);
+
+    let feature = rows.iter().find(|r| r.name == "feature").unwrap();
+    assert!(!feature.merged);
+    assert_eq!(feature.ahead, 1);
+    assert_eq!(feature.behind, 1);
+
+    let main = rows.iter().find(|r| r.name == "main").unwrap();
+    assert!(main.is_base);
+    assert!(main.is_head);
+    assert!(!main.merged);
+
+    // HEAD is pinned first
+    assert_eq!(rows.first().unwrap().name, "main");
+}
+
+#[test]
+fn worktree_listing_reports_branch_and_path() {
+    let (tempdir, repo) = init_repo_with_main();
+
+    let wt_path = tempdir.path().join("wt-feature");
+    repo.worktree("wt-feature", &wt_path, None).unwrap();
+
+    let worktrees = WorktreeInfo::list_all(&repo).unwrap();
+    assert_eq!(worktrees.len(), 1);
+    assert_eq!(worktrees[0].name, "wt-feature");
+    assert_eq!(worktrees[0].branch.as_deref(), Some("wt-feature"));
+    assert_eq!(
+        worktrees[0].path.canonicalize().unwrap(),
+        wt_path.canonicalize().unwrap()
+    );
+
+    // Triage rows pick up the worktree path
+    let (_, rows) = collect_triage(&repo, &worktrees).unwrap();
+    let row = rows.iter().find(|r| r.name == "wt-feature").unwrap();
+    assert!(row.worktree_path.is_some());
+}
+
+#[test]
+fn from_range_shows_branch_changes_only() {
+    let (_tempdir, repo) = init_repo_with_main();
+    let base_commit = repo.head().unwrap().peel_to_commit().unwrap();
+    let base_oid = base_commit.id();
+
+    // feature: two commits touching feature.txt
+    repo.branch("feature", &base_commit, false).unwrap();
+    repo.set_head("refs/heads/feature").unwrap();
+    commit_file(&repo, "feature.txt", "one\n", "feat 1");
+    let feature_tip = commit_file(&repo, "feature.txt", "one\ntwo\n", "feat 2");
+
+    // main advances independently
+    repo.set_head("refs/heads/main").unwrap();
+    repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    commit_file(&repo, "main.txt", "main\n", "main work");
+
+    let merge_base = repo
+        .merge_base(repo.head().unwrap().target().unwrap(), feature_tip)
+        .unwrap();
+    assert_eq!(merge_base, base_oid);
+
+    let diff = CommitDiffInfo::from_range(&repo, merge_base, feature_tip).unwrap();
+    assert_eq!(diff.total_files, 1);
+    assert_eq!(diff.files[0].path, Path::new("feature.txt"));
+    assert_eq!(diff.files[0].insertions, 2);
+    // main.txt (added on main after the merge base) must not appear
+    assert!(diff.files.iter().all(|f| f.path != Path::new("main.txt")));
+}


### PR DESCRIPTION
## Summary

Three features aimed at parallel-branch workflows — increasingly common now that AI coding agents spawn many worktrees and branches (`.claude/worktrees/`, `worktree-*`, etc.):

### 1. Worktree first-class support
- Linked worktrees are listed via git2 and refreshed with the graph
- Branches checked out in a worktree get a `⌂` marker in the graph (`[agent-task ⌂]`), and the commit detail pane shows the worktree path
- `w` creates a worktree for the selected branch (path input pre-filled with a sibling directory), `W` removes it (confirmation; refuses when dirty via `git worktree remove`)
- Checkout / branch deletion are guarded for branches checked out in another worktree — git2 does not enforce the CLI's "already checked out elsewhere" rule, so without this the other worktree could be corrupted

### 2. Branch triage list (`B`)
Full-screen list of local branches for cleaning up branch sprawl:
- ahead/behind vs the base branch (detected via `origin/HEAD` → `main` → `master`), `merged` / `base` badges, `⌂` worktree marker, last activity, commit subject
- `Enter` checkout, `d` delete (warns when not merged), `D` bulk-delete merged branches (HEAD / base / worktree-attached branches are excluded), `v` / `w` / `W` also work from the list
- Mouse: scroll, click to select, double-click to checkout

### 3. Branch review (`v`)
- Shows the cumulative diff `merge-base..branch` (= `git diff base...branch`) in the existing FileSelect / FileDiff views
- Status bar shows a `base…branch` badge and a REVIEW mode label
- Works from the graph and from the branch list

## Implementation notes

- Worktree add/remove shell out to `git`, matching the existing fetch/push pattern, so CLI locking and checkout rules apply
- Review plumbs a `DiffSource::Range` through FileSelect/FileDiff, reusing the diff viewer; the async uncommitted-diff sync is guarded so it never overwrites a review file list
- Auto-refresh is paused in the branch list, same as FileSelect/FileDiff
- Help popup, status bar hints, mouse routing, and the debug server (`branch_list` mode) are updated

## Test plan

- [x] `cargo test` (72 passed) — new `tests/branch_triage_test.rs` covers base-branch detection, triage ahead/behind/merged flags, worktree listing, and range diffs
- [x] `cargo clippy --all-targets` / `cargo fmt --check` clean
- [x] Verified end-to-end via the debug TUI (`--debug-listen`): ⌂ markers, worktree create/remove, checkout guard message, triage list rendering, bulk prune of merged branches, review badge + range file diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHpCigTLkn7MstZMcP9twP