### PR TITLE
🐛 Improve wheel scrolling responsiveness

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -667,6 +667,8 @@ impl App {
         }
 
         self.perf.record("refresh", refresh_started.elapsed());
+        self.pending_refresh = false;
+        self.last_refresh_time = Instant::now();
 
         Ok(())
     }
@@ -748,7 +750,7 @@ impl App {
     }
 
     /// Check if async fetch has completed and process the result
-    pub fn update_fetch_status(&mut self) {
+    pub fn update_fetch_status(&mut self, allow_refresh: bool) {
         let Some(rx) = &self.fetch_receiver else {
             return;
         };
@@ -763,10 +765,7 @@ impl App {
         match fetch_result {
             Ok(()) => {
                 self.reset_timers();
-                if matches!(
-                    self.mode,
-                    AppMode::FileSelect { .. } | AppMode::FileDiff { .. }
-                ) {
+                if !allow_refresh || self.repository_refresh_is_paused() {
                     self.pending_refresh = true;
                     self.set_message("Fetched from origin");
                 } else {
@@ -792,7 +791,7 @@ impl App {
     }
 
     /// Check if async push has completed and process the result
-    pub fn update_push_status(&mut self) {
+    pub fn update_push_status(&mut self, allow_refresh: bool) {
         let Some(rx) = &self.push_receiver else {
             return;
         };
@@ -805,7 +804,9 @@ impl App {
             Ok(()) => {
                 self.set_message("Pushed to origin");
                 self.reset_timers();
-                if let Err(e) = self.refresh(true) {
+                if !allow_refresh || self.repository_refresh_is_paused() {
+                    self.pending_refresh = true;
+                } else if let Err(e) = self.refresh(true) {
                     self.show_error(format!("Refresh failed: {e}"));
                 }
             }
@@ -833,16 +834,11 @@ impl App {
         if self.is_fetching() {
             return;
         }
-        // A synchronous refresh would delay any queued input by its full
-        // duration (perceived as a slow click); let input win and retry on
-        // the next tick.
-        if crossterm::event::poll(Duration::ZERO).unwrap_or(false) {
+        if self.repository_refresh_is_paused() {
             return;
         }
-        if matches!(
-            self.mode,
-            AppMode::FileSelect { .. } | AppMode::FileDiff { .. }
-        ) {
+        if self.pending_refresh {
+            self.apply_pending_refresh();
             return;
         }
 
@@ -863,10 +859,17 @@ impl App {
                 >= refresh_config.refresh_interval
         {
             if let Err(e) = self.refresh(false) {
+                self.last_refresh_time = now;
                 self.set_message(format!("Auto-refresh failed: {e}"));
             }
-            self.last_refresh_time = now;
         }
+    }
+
+    fn repository_refresh_is_paused(&self) -> bool {
+        matches!(
+            self.mode,
+            AppMode::FileSelect { .. } | AppMode::FileDiff { .. }
+        )
     }
 
     /// Start fetch in background
@@ -1675,11 +1678,16 @@ impl App {
 
     fn return_to_normal(&mut self) {
         self.mode = AppMode::Normal;
-        if self.pending_refresh {
+    }
+
+    fn apply_pending_refresh(&mut self) {
+        if !self.pending_refresh {
+            return;
+        }
+        if let Err(e) = self.refresh(true) {
             self.pending_refresh = false;
-            if let Err(e) = self.refresh(true) {
-                self.set_message(format!("Refresh failed: {e}"));
-            }
+            self.last_refresh_time = Instant::now();
+            self.set_message(format!("Refresh failed: {e}"));
         }
     }
 
@@ -2639,5 +2647,95 @@ mod tests {
             .nodes
             .first()
             .is_some_and(|node| node.is_uncommitted));
+    }
+
+    #[test]
+    fn fetch_completion_defers_only_the_repository_refresh_during_input() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(tempdir.path()).unwrap();
+        commit_file(&repo, "tracked.txt", "tracked\n", "initial");
+        let mut app = make_app_from_repo(GitRepository::open(tempdir.path()).unwrap());
+        let (sender, receiver) = mpsc::channel();
+        app.fetch_receiver = Some(receiver);
+        sender.send(Ok(())).unwrap();
+
+        app.update_fetch_status(false);
+
+        assert!(!app.is_fetching());
+        assert!(app.pending_refresh);
+        assert_eq!(app.message.as_deref(), Some("Fetched from origin"));
+    }
+
+    #[test]
+    fn push_completion_defers_the_repository_refresh_in_file_select() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(tempdir.path()).unwrap();
+        commit_file(&repo, "tracked.txt", "tracked\n", "initial");
+        let mut app = make_app_from_repo(GitRepository::open(tempdir.path()).unwrap());
+        app.mode = AppMode::FileSelect {
+            selected_index: 0,
+            file_list: Vec::new(),
+        };
+        let (sender, receiver) = mpsc::channel();
+        app.push_receiver = Some(receiver);
+        app.set_message("Pushing...");
+        sender.send(Ok(())).unwrap();
+
+        app.update_push_status(true);
+
+        assert!(!app.is_pushing());
+        assert!(app.pending_refresh);
+        assert_eq!(app.message.as_deref(), Some("Pushed to origin"));
+    }
+
+    #[test]
+    fn return_to_normal_keeps_a_pending_refresh_deferred() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(tempdir.path()).unwrap();
+        commit_file(&repo, "tracked.txt", "tracked\n", "initial");
+        let mut app = make_app_from_repo(GitRepository::open(tempdir.path()).unwrap());
+        app.mode = AppMode::FileSelect {
+            selected_index: 0,
+            file_list: Vec::new(),
+        };
+        app.pending_refresh = true;
+
+        app.handle_action(Action::Cancel).unwrap();
+
+        assert!(matches!(app.mode, AppMode::Normal));
+        assert!(app.pending_refresh);
+        assert!(app.perf.ops().all(|(name, _)| name != "refresh"));
+    }
+
+    #[test]
+    fn pending_refresh_is_applied_once() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(tempdir.path()).unwrap();
+        commit_file(&repo, "tracked.txt", "tracked\n", "initial");
+        let mut app = make_app_from_repo(GitRepository::open(tempdir.path()).unwrap());
+        app.pending_refresh = true;
+
+        app.check_auto_refresh();
+
+        assert!(!app.pending_refresh);
+        let refresh_count = app
+            .perf
+            .ops()
+            .find(|(name, _)| *name == "refresh")
+            .unwrap()
+            .1
+            .count;
+
+        app.check_auto_refresh();
+
+        assert_eq!(
+            app.perf
+                .ops()
+                .find(|(name, _)| *name == "refresh")
+                .unwrap()
+                .1
+                .count,
+            refresh_count
+        );
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,49 +1,232 @@
 //! Event loop and input handling
 
-use std::time::Duration;
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TryRecvError, TrySendError};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use std::thread;
+use std::time::{Duration, Instant};
 
-use anyhow::Result;
-use crossterm::event::{self, Event, MouseEventKind};
+use anyhow::{anyhow, Context, Result};
+use crossterm::event::{self, Event, MouseEvent, MouseEventKind};
 
-/// Poll for events (100ms timeout) and drain everything already queued.
-///
-/// Processing the whole batch before the next render keeps scrolling
-/// responsive: rendering once per event made queued scroll events burst
-/// out at unpredictable speed (issue #12).
-pub fn poll_events() -> Result<Vec<Event>> {
-    if !event::poll(Duration::from_millis(100))? {
-        return Ok(Vec::new());
+const EVENT_POLL_TIMEOUT: Duration = Duration::from_millis(100);
+const MAX_EVENTS_PER_BATCH: usize = 512;
+const MAX_BUFFERED_EVENTS: usize = MAX_EVENTS_PER_BATCH * 2;
+const SCROLL_BURST_GAP: Duration = Duration::from_millis(1);
+const MAX_EVENTS_PER_NOTCH: usize = 8;
+
+#[derive(Debug, Default)]
+pub struct EventBatch {
+    events: Vec<InputEvent>,
+    raw_count: usize,
+    retained_count: usize,
+}
+
+impl EventBatch {
+    pub fn had_input(&self) -> bool {
+        self.raw_count > 0 || self.retained_count > 0
     }
-    let mut events = vec![event::read()?];
-    while event::poll(Duration::ZERO)? {
-        events.push(event::read()?);
+
+    pub fn raw_count(&self) -> usize {
+        self.raw_count
     }
-    Ok(coalesce_scroll_events(events))
+
+    pub fn retained_count(&self) -> usize {
+        self.retained_count
+    }
+
+    pub fn into_events(self) -> Vec<InputEvent> {
+        self.events
+    }
+}
+
+#[derive(Debug)]
+pub enum InputEvent {
+    Terminal(Event),
+    Scroll { mouse: MouseEvent, steps: usize },
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct TimedEvent {
+    event: Event,
+    arrived_at: Instant,
+}
+
+enum InputMessage {
+    Event(Event),
+    Error(String),
+}
+
+pub struct EventReader {
+    receiver: Receiver<InputMessage>,
+    raw_count: Arc<AtomicUsize>,
+}
+
+impl EventReader {
+    pub fn new() -> Result<Self> {
+        let (sender, receiver) = mpsc::sync_channel(MAX_BUFFERED_EVENTS);
+        let raw_count = Arc::new(AtomicUsize::new(0));
+        let reader_raw_count = Arc::clone(&raw_count);
+        let _reader_thread = thread::Builder::new()
+            .name("keifu-input".to_string())
+            .spawn(move || {
+                let mut scroll = ScrollNormalizer::default();
+                loop {
+                    match event::read() {
+                        Ok(event) => {
+                            reader_raw_count.fetch_add(1, Ordering::Relaxed);
+                            let Some(event) =
+                                normalize_terminal_event(&mut scroll, event, Instant::now())
+                            else {
+                                continue;
+                            };
+                            if enqueue_event(&sender, event).is_err() {
+                                break;
+                            }
+                        }
+                        Err(error) => {
+                            let _ = sender.send(InputMessage::Error(error.to_string()));
+                            break;
+                        }
+                    }
+                }
+            })
+            .context("Failed to start terminal input reader")?;
+
+        Ok(Self {
+            receiver,
+            raw_count,
+        })
+    }
+
+    pub fn poll_events(&mut self) -> Result<EventBatch> {
+        let first = match self.receiver.recv_timeout(EVENT_POLL_TIMEOUT) {
+            Ok(message) => message,
+            Err(RecvTimeoutError::Timeout) => {
+                return Ok(EventBatch {
+                    raw_count: self.raw_count.swap(0, Ordering::Relaxed),
+                    ..EventBatch::default()
+                });
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(anyhow!("Terminal input reader stopped unexpectedly"));
+            }
+        };
+
+        let first = Self::event_from_message(first)?;
+        let mut events = Vec::with_capacity(16);
+        let mut retained_count = push_input_event(first, &mut events);
+        let mut message_count = 1;
+        while message_count < MAX_EVENTS_PER_BATCH {
+            match self.receiver.try_recv() {
+                Ok(message) => {
+                    message_count += 1;
+                    let event = Self::event_from_message(message)?;
+                    retained_count += push_input_event(event, &mut events);
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    return Err(anyhow!("Terminal input reader stopped unexpectedly"));
+                }
+            }
+        }
+
+        Ok(EventBatch {
+            events,
+            raw_count: self.raw_count.swap(0, Ordering::Relaxed),
+            retained_count,
+        })
+    }
+
+    fn event_from_message(message: InputMessage) -> Result<Event> {
+        match message {
+            InputMessage::Event(event) => Ok(event),
+            InputMessage::Error(error) => Err(anyhow!("Terminal input failed: {error}")),
+        }
+    }
+}
+
+fn enqueue_event(sender: &SyncSender<InputMessage>, event: Event) -> std::result::Result<(), ()> {
+    let is_scroll_event = matches!(&event, Event::Mouse(mouse) if is_scroll(mouse.kind));
+    let message = InputMessage::Event(event);
+    if is_scroll_event {
+        match sender.try_send(message) {
+            Ok(()) | Err(TrySendError::Full(_)) => Ok(()),
+            Err(TrySendError::Disconnected(_)) => Err(()),
+        }
+    } else {
+        sender.send(message).map_err(|_| ())
+    }
+}
+
+fn normalize_terminal_event(
+    scroll: &mut ScrollNormalizer,
+    event: Event,
+    arrived_at: Instant,
+) -> Option<Event> {
+    match event {
+        Event::Mouse(mouse) if is_scroll(mouse.kind) => scroll
+            .should_retain(mouse, arrived_at)
+            .then_some(Event::Mouse(mouse)),
+        other => {
+            scroll.reset();
+            Some(other)
+        }
+    }
+}
+
+fn push_input_event(event: Event, events: &mut Vec<InputEvent>) -> usize {
+    match event {
+        Event::Mouse(mouse) if is_scroll(mouse.kind) => match events.last_mut() {
+            Some(InputEvent::Scroll {
+                mouse: previous,
+                steps,
+            }) if *previous == mouse => *steps += 1,
+            _ => events.push(InputEvent::Scroll { mouse, steps: 1 }),
+        },
+        other => events.push(InputEvent::Terminal(other)),
+    }
+    1
 }
 
 fn is_scroll(kind: MouseEventKind) -> bool {
     matches!(kind, MouseEventKind::ScrollUp | MouseEventKind::ScrollDown)
 }
 
-/// Collapse runs of consecutive same-direction scroll events into one.
-///
-/// Terminals emit a different number of scroll events per wheel notch
-/// (1 in Windows Terminal, ~3 in kitty, ~8 in Ghostty), and there is no
-/// protocol-level notion of a "notch". A notch's events arrive as one burst,
-/// so within a drained batch one same-direction run ≈ one notch. Collapsing
-/// the run normalizes wheel speed to one step per notch everywhere
-/// (issue #12).
-fn coalesce_scroll_events(events: Vec<Event>) -> Vec<Event> {
-    let mut out: Vec<Event> = Vec::with_capacity(events.len());
-    for event in events {
-        if let (Event::Mouse(current), Some(Event::Mouse(prev))) = (&event, out.last()) {
-            if is_scroll(current.kind) && current.kind == prev.kind {
-                continue;
-            }
+#[derive(Debug, Default)]
+struct ScrollNormalizer {
+    last_scroll: Option<(Instant, MouseEvent)>,
+    burst_count: usize,
+}
+
+impl ScrollNormalizer {
+    fn should_retain(&mut self, mouse: MouseEvent, arrived_at: Instant) -> bool {
+        let continues_burst = self.last_scroll.is_some_and(|(last, last_mouse)| {
+            last_mouse == mouse && arrived_at.saturating_duration_since(last) < SCROLL_BURST_GAP
+        });
+        self.last_scroll = Some((arrived_at, mouse));
+
+        if !continues_burst {
+            self.burst_count = 1;
+            return true;
         }
-        out.push(event);
+
+        self.burst_count += 1;
+        if self.burst_count > MAX_EVENTS_PER_NOTCH {
+            self.burst_count = 1;
+            true
+        } else {
+            false
+        }
     }
-    out
+
+    fn reset(&mut self) {
+        self.last_scroll = None;
+        self.burst_count = 0;
+    }
 }
 
 #[cfg(test)]
@@ -52,36 +235,243 @@ mod tests {
 
     use super::*;
 
-    fn scroll(kind: MouseEventKind) -> Event {
-        Event::Mouse(MouseEvent {
-            kind,
-            column: 5,
-            row: 5,
-            modifiers: KeyModifiers::NONE,
-        })
+    fn scroll(kind: MouseEventKind, arrived_at: Instant) -> TimedEvent {
+        TimedEvent {
+            event: Event::Mouse(MouseEvent {
+                kind,
+                column: 5,
+                row: 5,
+                modifiers: KeyModifiers::NONE,
+            }),
+            arrived_at,
+        }
+    }
+
+    fn paced_scrolls(
+        kind: MouseEventKind,
+        count: usize,
+        start: Instant,
+        gap: Duration,
+    ) -> Vec<TimedEvent> {
+        (0..count)
+            .map(|index| scroll(kind, start + gap * index as u32))
+            .collect()
+    }
+
+    fn retained_count(events: &[InputEvent]) -> usize {
+        events
+            .iter()
+            .map(|event| match event {
+                InputEvent::Terminal(_) => 1,
+                InputEvent::Scroll { steps, .. } => *steps,
+            })
+            .sum()
+    }
+
+    fn normalize(
+        scroll: &mut ScrollNormalizer,
+        events: impl IntoIterator<Item = TimedEvent>,
+    ) -> Vec<InputEvent> {
+        let mut normalized = Vec::new();
+        for timed in events {
+            if let Some(event) = normalize_terminal_event(scroll, timed.event, timed.arrived_at) {
+                push_input_event(event, &mut normalized);
+            }
+        }
+        normalized
     }
 
     #[test]
-    fn collapses_same_direction_scroll_bursts() {
-        let burst = vec![
-            scroll(MouseEventKind::ScrollDown),
-            scroll(MouseEventKind::ScrollDown),
-            scroll(MouseEventKind::ScrollDown),
-        ];
-        assert_eq!(coalesce_scroll_events(burst).len(), 1);
+    fn normalizes_amplified_events_from_one_notch() {
+        let now = Instant::now();
+        for count in [1, 3, MAX_EVENTS_PER_NOTCH] {
+            let mut normalizer = ScrollNormalizer::default();
+            let events = paced_scrolls(
+                MouseEventKind::ScrollDown,
+                count,
+                now,
+                Duration::from_micros(50),
+            );
+
+            let normalized = normalize(&mut normalizer, events);
+
+            assert_eq!(retained_count(&normalized), 1);
+        }
     }
 
     #[test]
-    fn keeps_direction_changes_and_other_events() {
-        let key = Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+    fn keeps_each_amplified_notch_in_a_fast_gesture() {
+        let now = Instant::now();
+        let events = (0..20).flat_map(|notch| {
+            paced_scrolls(
+                MouseEventKind::ScrollDown,
+                MAX_EVENTS_PER_NOTCH,
+                now + Duration::from_millis(notch * 4),
+                Duration::from_micros(50),
+            )
+        });
+        let mut normalizer = ScrollNormalizer::default();
+
+        let normalized = normalize(&mut normalizer, events);
+
+        assert_eq!(retained_count(&normalized), 20);
+    }
+
+    #[test]
+    fn retains_fast_scroll_distance_independent_of_render_batches() {
+        let now = Instant::now();
+        let events = paced_scrolls(
+            MouseEventKind::ScrollDown,
+            60,
+            now,
+            Duration::from_millis(4),
+        );
+        let mut one_batch = ScrollNormalizer::default();
+        let normalized = normalize(&mut one_batch, events);
+        let one_batch_total = retained_count(&normalized);
+        assert!(matches!(
+            normalized.as_slice(),
+            [InputEvent::Scroll { steps: 60, .. }]
+        ));
+
+        let mut split_batches = ScrollNormalizer::default();
+        let split_total: usize = paced_scrolls(
+            MouseEventKind::ScrollDown,
+            60,
+            now,
+            Duration::from_millis(4),
+        )
+        .chunks(5)
+        .map(|batch| retained_count(&normalize(&mut split_batches, batch.to_vec())))
+        .sum();
+
+        assert_eq!(one_batch_total, 60);
+        assert_eq!(split_total, 60);
+    }
+
+    #[test]
+    fn bounds_a_sub_millisecond_free_spin_stream() {
+        let now = Instant::now();
+        let mut normalizer = ScrollNormalizer::default();
+        let events = paced_scrolls(
+            MouseEventKind::ScrollDown,
+            80,
+            now,
+            Duration::from_micros(50),
+        );
+
+        let normalized = normalize(&mut normalizer, events);
+
+        assert_eq!(retained_count(&normalized), 10);
+    }
+
+    #[test]
+    fn keeps_direction_changes_and_other_events_in_order() {
+        let now = Instant::now();
+        let mut normalizer = ScrollNormalizer::default();
+        let key = TimedEvent {
+            event: Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+            arrived_at: now + Duration::from_micros(200),
+        };
         let events = vec![
-            scroll(MouseEventKind::ScrollDown),
-            scroll(MouseEventKind::ScrollDown),
-            scroll(MouseEventKind::ScrollUp),
-            key.clone(),
-            scroll(MouseEventKind::ScrollDown),
+            scroll(MouseEventKind::ScrollDown, now),
+            scroll(MouseEventKind::ScrollDown, now + Duration::from_micros(50)),
+            key,
+            scroll(MouseEventKind::ScrollUp, now + Duration::from_micros(250)),
+            scroll(MouseEventKind::ScrollUp, now + Duration::from_micros(300)),
         ];
-        let out = coalesce_scroll_events(events);
-        assert_eq!(out.len(), 4); // down, up, key, down
+
+        let normalized = normalize(&mut normalizer, events);
+
+        assert_eq!(retained_count(&normalized), 3);
+        assert!(matches!(
+            normalized.as_slice(),
+            [
+                InputEvent::Scroll {
+                    mouse: MouseEvent {
+                        kind: MouseEventKind::ScrollDown,
+                        ..
+                    },
+                    steps: 1
+                },
+                InputEvent::Terminal(Event::Key(_)),
+                InputEvent::Scroll {
+                    mouse: MouseEvent {
+                        kind: MouseEventKind::ScrollUp,
+                        ..
+                    },
+                    steps: 1
+                }
+            ]
+        ));
+    }
+
+    #[test]
+    fn keeps_scrolls_when_the_pointer_or_modifiers_change() {
+        let now = Instant::now();
+        let mut normalizer = ScrollNormalizer::default();
+        let mut moved = scroll(MouseEventKind::ScrollDown, now + Duration::from_micros(50));
+        let Event::Mouse(mouse) = &mut moved.event else {
+            unreachable!();
+        };
+        mouse.column += 1;
+        let mut modified = scroll(MouseEventKind::ScrollDown, now + Duration::from_micros(100));
+        let Event::Mouse(mouse) = &mut modified.event else {
+            unreachable!();
+        };
+        mouse.modifiers = KeyModifiers::SHIFT;
+
+        let normalized = normalize(
+            &mut normalizer,
+            vec![scroll(MouseEventKind::ScrollDown, now), moved, modified],
+        );
+
+        assert_eq!(retained_count(&normalized), 3);
+    }
+
+    #[test]
+    fn one_millisecond_gap_starts_a_new_notch() {
+        let now = Instant::now();
+        let mut within_gap = ScrollNormalizer::default();
+        let within = normalize(
+            &mut within_gap,
+            vec![
+                scroll(MouseEventKind::ScrollDown, now),
+                scroll(MouseEventKind::ScrollDown, now + Duration::from_micros(999)),
+            ],
+        );
+        let mut at_boundary = ScrollNormalizer::default();
+        let boundary = normalize(
+            &mut at_boundary,
+            vec![
+                scroll(MouseEventKind::ScrollDown, now),
+                scroll(MouseEventKind::ScrollDown, now + Duration::from_millis(1)),
+            ],
+        );
+
+        assert_eq!(retained_count(&within), 1);
+        assert_eq!(retained_count(&boundary), 2);
+    }
+
+    #[test]
+    fn full_queue_drops_scroll_but_preserves_keyboard_input() {
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let scroll = scroll(MouseEventKind::ScrollDown, Instant::now()).event;
+        assert_eq!(enqueue_event(&sender, scroll.clone()), Ok(()));
+        assert_eq!(enqueue_event(&sender, scroll), Ok(()));
+
+        let key = Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        let key_sender = sender.clone();
+        let send_key = thread::spawn(move || enqueue_event(&key_sender, key));
+
+        assert!(matches!(
+            receiver.recv_timeout(Duration::from_secs(1)),
+            Ok(InputMessage::Event(Event::Mouse(_)))
+        ));
+        assert_eq!(send_key.join().unwrap(), Ok(()));
+        assert!(matches!(
+            receiver.recv_timeout(Duration::from_secs(1)),
+            Ok(InputMessage::Event(Event::Key(_)))
+        ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,22 @@
 //! keifu: a TUI tool that shows Git commit graphs
 
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use clap::Parser;
 use crossterm::event::Event;
 
 use keifu::{
-    app::App, debug_server, event::poll_events, git::configure_git_extensions,
-    keybindings::map_key_to_action, logging, mouse, tui, ui,
+    app::App,
+    debug_server,
+    event::{EventReader, InputEvent},
+    git::configure_git_extensions,
+    keybindings::map_key_to_action,
+    logging, mouse, tui, ui,
 };
+
+const MAINTENANCE_IDLE_PERIOD: Duration = Duration::from_millis(250);
 
 #[derive(Parser)]
 #[command(name = "keifu")]
@@ -53,6 +60,14 @@ fn main() -> Result<()> {
 
     // Initialize terminal
     let mut terminal = tui::init()?;
+    let mut event_reader = match EventReader::new() {
+        Ok(reader) => reader,
+        Err(error) => {
+            let _ = tui::restore();
+            return Err(error);
+        }
+    };
+    let mut last_user_input = Instant::now();
 
     // Main loop
     loop {
@@ -63,25 +78,27 @@ fn main() -> Result<()> {
         })?;
         app.perf.record("draw", draw_started.elapsed());
 
-        // Check if async fetch/push has completed
-        app.update_fetch_status();
-        app.update_push_status();
-
-        // Auto-refresh check
-        app.check_auto_refresh();
-
         // Exit check
         if app.should_quit {
             break;
         }
 
         // Process all queued events before the next render
-        let events = poll_events()?;
+        let batch = event_reader.poll_events()?;
+        if batch.had_input() {
+            last_user_input = Instant::now();
+        }
+        let raw_count = batch.raw_count();
+        let retained_count = batch.retained_count();
+        let events = batch.into_events();
+        if raw_count > 0 || retained_count > 0 {
+            tracing::trace!(raw_count, retained_count, "input batch normalized");
+        }
         if !events.is_empty() {
             let events_started = std::time::Instant::now();
             for event in events {
                 match event {
-                    Event::Key(key) => {
+                    InputEvent::Terminal(Event::Key(key)) => {
                         if let Some(action) = map_key_to_action(key, &app.mode) {
                             if let Err(e) = app.handle_action(action) {
                                 // Show errors in the UI
@@ -89,9 +106,13 @@ fn main() -> Result<()> {
                             }
                         }
                     }
-                    Event::Mouse(mouse_event) => {
+                    InputEvent::Terminal(Event::Mouse(mouse_event)) => {
                         mouse::handle_mouse(&mut app, mouse_event);
                     }
+                    InputEvent::Scroll {
+                        mouse: mouse_event,
+                        steps,
+                    } => mouse::handle_scroll(&mut app, mouse_event, steps),
                     // Resize events trigger redraw automatically
                     _ => {}
                 }
@@ -114,6 +135,15 @@ fn main() -> Result<()> {
                 );
                 let _ = command.reply.send(response);
             }
+        }
+
+        let allow_repository_refresh = last_user_input.elapsed() >= MAINTENANCE_IDLE_PERIOD;
+        app.update_fetch_status(allow_repository_refresh);
+        app.update_push_status(allow_repository_refresh);
+        // Repository refreshes are synchronous, so they must not compete with
+        // an active input gesture for the UI thread.
+        if allow_repository_refresh {
+            app.check_auto_refresh();
         }
     }
 

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -18,11 +18,20 @@ const DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(400);
 
 pub fn handle_mouse(app: &mut App, event: MouseEvent) {
     match event.kind {
-        MouseEventKind::ScrollDown => handle_scroll(app, 1, event.column, event.row),
-        MouseEventKind::ScrollUp => handle_scroll(app, -1, event.column, event.row),
+        MouseEventKind::ScrollDown | MouseEventKind::ScrollUp => handle_scroll(app, event, 1),
         MouseEventKind::Down(MouseButton::Left) => handle_click(app, event.column, event.row),
         _ => {}
     }
+}
+
+pub fn handle_scroll(app: &mut App, event: MouseEvent, steps: usize) {
+    let steps = i32::try_from(steps).unwrap_or(i32::MAX);
+    let delta = match event.kind {
+        MouseEventKind::ScrollDown => steps,
+        MouseEventKind::ScrollUp => -steps,
+        _ => return,
+    };
+    handle_scroll_delta(app, delta, event.column, event.row);
 }
 
 fn dispatch(app: &mut App, action: Action) {
@@ -42,39 +51,52 @@ fn inner_row(rect: Rect, y: u16) -> Option<u16> {
     (y >= top && y < bottom).then(|| y - top)
 }
 
-fn handle_scroll(app: &mut App, delta: i32, x: u16, y: u16) {
+fn offset_index(current: usize, max: usize, delta: i32) -> usize {
+    if delta >= 0 {
+        current.saturating_add(delta as usize).min(max)
+    } else {
+        current.saturating_sub(delta.unsigned_abs() as usize)
+    }
+}
+
+fn handle_scroll_delta(app: &mut App, delta: i32, x: u16, y: u16) {
     match &app.mode {
         AppMode::FileDiff { .. } => {
-            let action = if delta > 0 {
-                Action::ScrollDown
-            } else {
-                Action::ScrollUp
+            let viewport = app.diff_viewport_height as usize;
+            let AppMode::FileDiff {
+                total_lines,
+                scroll_offset,
+                ..
+            } = &mut app.mode
+            else {
+                return;
             };
-            // Diff view: 3x scroll speed
-            for _ in 0..3 {
-                dispatch(app, action.clone());
-            }
+            let max_scroll = total_lines.saturating_sub(viewport);
+            *scroll_offset = offset_index(*scroll_offset, max_scroll, delta.saturating_mul(3));
         }
         AppMode::Help => {
-            let action = if delta > 0 {
-                Action::ScrollDown
+            if delta >= 0 {
+                app.help_scroll = app
+                    .help_scroll
+                    .saturating_add(u16::try_from(delta).unwrap_or(u16::MAX));
             } else {
-                Action::ScrollUp
-            };
-            dispatch(app, action);
+                app.help_scroll = app
+                    .help_scroll
+                    .saturating_sub(u16::try_from(delta.unsigned_abs()).unwrap_or(u16::MAX));
+            }
         }
         AppMode::Normal | AppMode::FileSelect { .. } => {
             let layout = app.layout;
             if contains(layout.commit_detail, x, y) {
                 app.scroll_detail(delta);
             } else if contains(layout.files, x, y) {
-                if matches!(app.mode, AppMode::FileSelect { .. }) {
-                    let action = if delta > 0 {
-                        Action::FileSelectDown
-                    } else {
-                        Action::FileSelectUp
-                    };
-                    dispatch(app, action);
+                if let AppMode::FileSelect {
+                    selected_index,
+                    file_list,
+                } = &mut app.mode
+                {
+                    *selected_index =
+                        offset_index(*selected_index, file_list.len().saturating_sub(1), delta);
                 }
             } else if contains(layout.graph, x, y) && matches!(app.mode, AppMode::Normal) {
                 app.move_selection(delta);


### PR DESCRIPTION
## Summary

- Read terminal input on a dedicated thread and pass it through a bounded queue instead of coupling reads to the render loop.
- Normalize identical wheel events at the reader, aggregate their distance into `steps`, and apply the result in O(1) per pane.
- Process fetch and push completion immediately while deferring synchronous repository refreshes until 250 ms after the most recent input.
- Add regression coverage for input ordering, terminal wheel amplification, queue overflow, and deferred refreshes.

## Root cause

The previous loop read terminal events after rendering and collapsed each same-direction scroll run to one event per render batch. A slower render therefore grouped more physical inputs into the same batch and discarded more scroll distance. Synchronous repository refreshes, which take about 15 ms in this repository, could also run on the UI thread during an active gesture and add visible stalls.

## Measurements

Sending 60 scroll-down events at 4 ms intervals through a 300x100 real PTY:

| | Selection movement |
| --- | ---: |
| Before | 14 / 60 |
| After | 60 / 60 |

The final commit was also verified against a 140x40 real TUI with a drive → dump → assert loop. `selected_index` moved from `0` to `60`, and the rendered heading matched `Commits 61/241`. No synchronous refresh ran during the input gesture; the refresh ran only after the following idle period.

## Design boundary

The mouse protocol does not identify physical wheel notches. Identical `MouseEvent`s arriving less than 1 ms apart are therefore normalized to one step per group of up to eight events. If reader scheduling is delayed and input is already buffered, multiple notches can be interpreted as one burst. Unlike the previous implementation, however, the new path always retains at least one step per eight events instead of collapsing an entire run to one event.

When the bounded queue is full, only scroll events may be dropped. Keyboard, click, resize, and error events remain ordered and are preserved.

## Verification

- `cargo fmt --check`
- `cargo test` — 91 tests passed
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- Real TUI drive → dump → assert coverage for Normal, Help, and FileSelect modes
- Raw SGR mouse events sent through a real PTY to verify the terminal input layer
